### PR TITLE
Use bnd-maven-plugin. Minimize required config

### DIFF
--- a/code/api/bnd.bnd
+++ b/code/api/bnd.bnd
@@ -1,0 +1,3 @@
+Export-Package: \
+	org.apache.tamaya,\
+	org.apache.tamaya.spi

--- a/code/api/pom.xml
+++ b/code/api/pom.xml
@@ -27,12 +27,14 @@ under the License.
 
     <artifactId>tamaya-api</artifactId>
     <name>Apache Tamaya API</name>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
 
     <description>
         The API for accessing configuration data.
     </description>
-
+    
+    <url>http://tamaya.incubator.apache.org</url>
+    
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -47,34 +49,6 @@ under the License.
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Export-Package>
-                            org.apache.tamaya,
-                            org.apache.tamaya.spi
-                        </Export-Package>
-                        <!--<Require-Capability>-->
-                            <!--osgi.extender;-->
-                            <!--filter:="(osgi.extender=osgi.serviceloader.processor)",-->
-                            <!--osgi.serviceloader;-->
-                            <!--filter:="(org.apache.tamaya.spi.ServiceContext)";-->
-                            <!--cardinality:=multiple;-->
-                            <!--filter:="(org.apache.tamaya.spi.ConfigurationProviderSpi)";-->
-                            <!--cardinality:=multiple-->
-                        <!--</Require-Capability>-->
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/code/core/bnd.bnd
+++ b/code/core/bnd.bnd
@@ -1,0 +1,5 @@
+Export-Package: \
+	org.apache.tamaya.core,\
+	org.apache.tamaya.core.propertysource,\
+	org.apache.tamaya.core.provider
+Bundle-Activator: org.apache.tamaya.core.internal.OSGIActivator

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -67,36 +67,4 @@ under the License.
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                            org.apache.tamaya,
-                            org.apache.tamaya.spi,
-                            javax.annotation,
-                            *
-                        </Import-Package>
-                        <Private-Package>
-                            org.apache.tamaya.core.internal,
-                            org.apache.tamaya.core.internal.converters
-                        </Private-Package>
-                        <Export-Package>
-                            org.apache.tamaya.core,
-                            org.apache.tamaya.core.propertysource,
-                            org.apache.tamaya.core.provider
-                        </Export-Package>
-                        <Bundle-Activator>
-                            org.apache.tamaya.core.internal.OSGIActivator
-                        </Bundle-Activator>
-                    </instructions>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -458,36 +458,6 @@ under the License.
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.2.0</version>
-                    <inherited>true</inherited>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <instructions>
-                            <Bundle-DocURL>http://tamaya.incubator.apache.org</Bundle-DocURL>
-                            <Bundle-SymbolicName>
-                                ${project.groupId}.${project.artifactId}
-                            </Bundle-SymbolicName>
-                            <Bundle-Vendor>The Apache Software Foundation</Bundle-Vendor>
-                        </instructions>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>cleanVersions</id>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>cleanVersions</goal>
-                            </goals>
-                            <configuration>
-                                <versions>
-                                    <karaf.osgi.version>${osgi.version}</karaf.osgi.version>
-                                </versions>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-publish-plugin</artifactId>
                     <version>1.1</version>
@@ -713,6 +683,28 @@ under the License.
                     <preparationGoals>clean install</preparationGoals>
                 </configuration>
             </plugin>
+            <plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The current OSGi config is quite verbose and relies on packaging bundle.
In this PR I switch to using the bnd-maven-plugin and try to minimize the required config.

The needed settings per bundle are defined in bnd.bnd files which have a simple syntax. Bndtools also provides a nice editor for these files but it is not required.
Apart from that the individual projects then need no special setup in the pom.