### PR TITLE
TAMAYA-326: Fix bug in ordinal comparison in ServiceContextManager

### DIFF
--- a/code/api/src/main/java/org/apache/tamaya/spi/ServiceContextManager.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/ServiceContextManager.java
@@ -57,9 +57,8 @@ public final class ServiceContextManager {
         try {
             int highestOrdinal = 0;
             for (ServiceContext serviceContext : ServiceLoader.load(ServiceContext.class)) {
-                if(highestServiceContext==null){
-                    highestServiceContext = serviceContext;
-                }else if (serviceContext.ordinal() > highestOrdinal) {
+                if (highestServiceContext == null
+                        || serviceContext.ordinal() > highestOrdinal) {
                     highestServiceContext = serviceContext;
                     highestOrdinal = serviceContext.ordinal();
                 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/TestLowerOrdinalServiceContext.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/TestLowerOrdinalServiceContext.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tamaya.spi;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
+
+/**
+ * This class implements the (default)
+ * {@link org.apache.tamaya.spi.ServiceContext} interface and hereby uses the
+ * JDK {@link java.util.ServiceLoader} to load the services required.
+ */
+public final class TestLowerOrdinalServiceContext implements ServiceContext {
+
+    private final RuntimeException ex = new RuntimeException("Lower ordinal Service Context was used.");
+
+    @Override
+    public int ordinal() {
+        return 1;
+    }
+
+    @Override
+    public <T> T getService(Class<T> serviceType) {
+        throw ex;
+    }
+
+    @Override
+    public <T> T create(Class<T> serviceType) {
+        throw ex;
+    }
+
+    @Override
+    public <T> List<T> getServices(Class<T> serviceType) {
+        throw ex;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String resource, ClassLoader cl) throws IOException {
+        throw ex;
+    }
+
+    @Override
+    public URL getResource(String resource, ClassLoader cl) {
+        throw ex;
+    }
+
+}

--- a/code/api/src/test/java/org/apache/tamaya/spi/TestServiceContext.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/TestServiceContext.java
@@ -37,7 +37,7 @@ public final class TestServiceContext implements ServiceContext {
 
     @Override
     public int ordinal() {
-        return 1;
+        return 5;
     }
 
     @SuppressWarnings("rawtypes")

--- a/code/api/src/test/resources/META-INF/services/org.apache.tamaya.spi.ServiceContext
+++ b/code/api/src/test/resources/META-INF/services/org.apache.tamaya.spi.ServiceContext
@@ -17,3 +17,4 @@
 # under the License.
 #
 org.apache.tamaya.spi.TestServiceContext
+org.apache.tamaya.spi.TestLowerOrdinalServiceContext


### PR DESCRIPTION
While adding some test coverage on the api, I found that
org.apache.tamaya.spi.ServiceContextManager has a bug as it searches for
the default service provider in loadDefaultServiceProvider.  Namely, the
"highestOrdinal" is not set after the first service provider is found,
so any following service provider with an ordinal higher than 0 will be
used, even if that ordinal is lower than the first one's.  This patch
fixes the logic, and adds tests to cover the case.