### PR TITLE
TAMAYA-328: Let CharConverter parse a single apostrophe character

### DIFF
--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CharConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CharConverter.java
@@ -49,6 +49,9 @@ public class CharConverter implements PropertyConverter<Character>{
         }
         if(trimmed.startsWith("'")) {
             try {
+                if (trimmed.length() == 1){
+                    return '\'';
+                }
                 trimmed = trimmed.substring(1, trimmed.length() - 1);
                 if (trimmed.isEmpty()) {
                     return null;

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
@@ -54,6 +54,14 @@ public class CharConverterTest {
     }
 
     @Test
+    public void testConvert_Character_SingleQuote() throws Exception {
+        Configuration config = ConfigurationProvider.getConfiguration();
+        Character valueRead = config.get("tests.converter.char.single-quote", Character.class);
+        assertThat(valueRead).isNotNull();
+        assertEquals(valueRead.charValue(), '\'');
+    }
+
+    @Test
     public void testConvert_Character_WithWhitespace_Before() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f-before", Character.class);

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConverterTestsPropertySource.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConverterTestsPropertySource.java
@@ -101,6 +101,8 @@ public class ConverterTestsPropertySource implements PropertySource{
                 return PropertyValue.of(key, "f", getName());
             case "tests.converter.char.d":
                 return PropertyValue.of(key, "'d'", getName());
+            case "tests.converter.char.single-quote":
+                return PropertyValue.of(key, "'", getName());
             case "tests.converter.char.f-before":
                 return PropertyValue.of(key, "  f", getName());
             case "tests.converter.char.f-after":


### PR DESCRIPTION
CharConverter uses paired apostrophes (') to delimit multi-character
strings and pulls the first into a Character object as needed.  That
works great, but has made it to where a single apostrophe by itself
cannot be used directly.  Entertainingly, "'''" works, but "'" throws an
exception.  This adds a simple check if the string is 1 character long
after having determined that it starts with an apostrophe.