### PR TITLE
TAMAYA-329: mapBoxedType should work with boolean[]

### DIFF
--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertyConverterManager.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertyConverterManager.java
@@ -324,8 +324,8 @@ public class PropertyConverterManager {
         if (parameterType == long[].class) {
             return TypeLiteral.class.cast(TypeLiteral.of(Long[].class));
         }
-        if (parameterType == boolean.class) {
-            return TypeLiteral.class.cast(TypeLiteral.of(Boolean.class));
+        if (parameterType == boolean[].class) {
+            return TypeLiteral.class.cast(TypeLiteral.of(Boolean[].class));
         }
         if (parameterType == char[].class) {
             return TypeLiteral.class.cast(TypeLiteral.of(Character[].class));


### PR DESCRIPTION
Simple copy-and-paste miss.  All the other primitives have both a simple
and array type check.  Boolean has two simple checks and no arrays.
This corrects the copy and adds a test.

I also hit "Format" on the test class so there's a bunch of whitespace changes.  I can undo that if it's stressful to anyone.