### PR TITLE
TAMAYA-217: Convert test assertions to AssertJ

### DIFF
--- a/code/api/pom.xml
+++ b/code/api/pom.xml
@@ -43,10 +43,6 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/code/api/src/test/java/org/apache/tamaya/ConfigExceptionTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigExceptionTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests instantiating {@link ConfigException}.
@@ -30,16 +30,16 @@ public class ConfigExceptionTest {
     @Test
     public void testCreationMessage(){
         ConfigException ex = new ConfigException("test");
-        assertNull(ex.getCause());
-        assertEquals(ex.getMessage(), "test");
+        assertThat(ex.getCause()).isNull();
+        assertThat("test").isEqualTo(ex.getMessage());
     }
 
     @Test
     public void testCreationMessageThrowable(){
         Exception e = new IllegalStateException("blabla");
         ConfigException ex = new ConfigException("test", e);
-        assertTrue(ex.getCause() == e);
-        assertEquals("test", ex.getMessage());
+        assertThat(ex.getCause() == e).isTrue();
+        assertThat(ex.getMessage()).isEqualTo("test");
     }
 
 }

--- a/code/api/src/test/java/org/apache/tamaya/ConfigurationProviderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigurationProviderTest.java
@@ -22,7 +22,7 @@ import org.apache.tamaya.spi.ConfigurationBuilder;
 import org.apache.tamaya.spi.ConfigurationContext;
 import org.apache.tamaya.spi.ConfigurationContextBuilder;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.mockito.Mockito;
 
 /**
@@ -40,7 +40,7 @@ public class ConfigurationProviderTest {
     @Test
     public void testCreateConfiguration() {
         Configuration result = ConfigurationProvider.createConfiguration(ConfigurationProvider.getConfiguration().getContext());
-        assertNotNull(result);
+        assertThat(result).isNotNull();
     }
     
     /**
@@ -50,15 +50,15 @@ public class ConfigurationProviderTest {
     @Test
     public void testGetSetConfigurationContext() {
         ConfigurationContext currentContext = ConfigurationProvider.getConfigurationContext();
-        assertTrue(currentContext instanceof ConfigurationContext);
+        assertThat(currentContext instanceof ConfigurationContext).isTrue();
         ConfigurationContext newContext = Mockito.mock(ConfigurationContext.class);
         try{
             ConfigurationProvider.setConfigurationContext(newContext);
-            assertEquals(newContext, ConfigurationProvider.getConfigurationContext());
+            assertThat(ConfigurationProvider.getConfigurationContext()).isEqualTo(newContext);
         }finally{
             ConfigurationProvider.setConfigurationContext(currentContext);
         }
-        assertEquals(currentContext, ConfigurationProvider.getConfigurationContext());
+        assertThat(ConfigurationProvider.getConfigurationContext()).isEqualTo(currentContext);
     }
 
     /**
@@ -67,15 +67,15 @@ public class ConfigurationProviderTest {
     @Test
     public void testGetSetConfiguration() {
         Configuration currentConfig = ConfigurationProvider.getConfiguration();
-        assertTrue(currentConfig instanceof Configuration);
+        assertThat(currentConfig instanceof Configuration).isTrue();
         Configuration newConfig = Mockito.mock(Configuration.class);
         try{
             ConfigurationProvider.setConfiguration(newConfig);
-            assertEquals(newConfig, ConfigurationProvider.getConfiguration());
+            assertThat(ConfigurationProvider.getConfiguration()).isEqualTo(newConfig);
         }finally{
             ConfigurationProvider.setConfiguration(currentConfig);
         }
-        assertEquals(currentConfig, ConfigurationProvider.getConfiguration());
+        assertThat(ConfigurationProvider.getConfiguration()).isEqualTo(currentConfig);
     }
 
     /**
@@ -84,7 +84,7 @@ public class ConfigurationProviderTest {
     @Test
     public void testGetConfigurationBuilder() {
         ConfigurationBuilder result = ConfigurationProvider.getConfigurationBuilder();
-        assertTrue(result instanceof ConfigurationBuilder);
+        assertThat(result instanceof ConfigurationBuilder).isTrue();
     }
 
     /**
@@ -93,11 +93,11 @@ public class ConfigurationProviderTest {
     @Test
     public void testGetConfigurationContextBuilder() {
         ConfigurationContextBuilder result = ConfigurationProvider.getConfigurationContextBuilder();
-        assertTrue(result instanceof ConfigurationContextBuilder);
+        assertThat(result instanceof ConfigurationContextBuilder).isTrue();
     }
 
     @Test
     public void testConstructorFails(){
-        assertTrue(ConfigurationProvider.class.getConstructors().length == 0);
+        assertThat(ConfigurationProvider.class.getConstructors().length == 0).isTrue();
     }
 }

--- a/code/api/src/test/java/org/apache/tamaya/ConfigurationTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigurationTest.java
@@ -19,70 +19,70 @@
 package org.apache.tamaya;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Test class that tests the default methods implemented on
  * {@link org.apache.tamaya.Configuration}. The provided
- * {@link org.apache.tamaya.TestConfiguration} is implemented with maximal use of
- * the default methods.
+ * {@link org.apache.tamaya.TestConfiguration} is implemented with maximal use
+ * of the default methods.
  */
 public class ConfigurationTest {
 
     @Test
     public void testget() throws Exception {
-        assertEquals(Boolean.TRUE, ConfigurationProvider.getConfiguration().get("booleanTrue", Boolean.class));
-        assertEquals(Boolean.FALSE, ConfigurationProvider.getConfiguration().get("booleanFalse", Boolean.class));
-        assertEquals((int) Byte.MAX_VALUE, (int) ConfigurationProvider.getConfiguration().get("byte", Byte.class));
-        assertEquals(Integer.MAX_VALUE, (int) ConfigurationProvider.getConfiguration().get("int", Integer.class));
-        assertEquals(Long.MAX_VALUE, (long) ConfigurationProvider.getConfiguration().get("long", Long.class));
-        assertEquals(Float.MAX_VALUE, (double) ConfigurationProvider.getConfiguration().get("float", Float.class), 0.0d);
-        assertEquals(Double.MAX_VALUE, ConfigurationProvider.getConfiguration().get("double", Double.class), 0.0d);
-        assertEquals("aStringValue", ConfigurationProvider.getConfiguration().get("String"));
+        assertThat(Boolean.TRUE).isEqualTo(ConfigurationProvider.getConfiguration().get("booleanTrue", Boolean.class));
+        assertThat(Boolean.FALSE).isEqualTo(ConfigurationProvider.getConfiguration().get("booleanFalse", Boolean.class));
+        assertThat((int) Byte.MAX_VALUE).isEqualTo((int) ConfigurationProvider.getConfiguration().get("byte", Byte.class));
+        assertThat(Integer.MAX_VALUE).isEqualTo((int) ConfigurationProvider.getConfiguration().get("int", Integer.class));
+        assertThat(Long.MAX_VALUE).isEqualTo((long) ConfigurationProvider.getConfiguration().get("long", Long.class));
+        assertThat(Float.MAX_VALUE).isCloseTo((float) ConfigurationProvider.getConfiguration().get("float", Float.class), within(0.001f));
+        assertThat(Double.MAX_VALUE).isEqualTo(ConfigurationProvider.getConfiguration().get("double", Double.class));
+        assertThat("aStringValue").isEqualTo(ConfigurationProvider.getConfiguration().get("String"));
     }
 
     @Test
     public void testGetBoolean() throws Exception {
-        assertTrue(ConfigurationProvider.getConfiguration().get("booleanTrue", Boolean.class));
-        assertFalse(ConfigurationProvider.getConfiguration().get("booleanFalse", Boolean.class));
-        assertFalse(ConfigurationProvider.getConfiguration().get("foorBar", Boolean.class));
+        assertThat(ConfigurationProvider.getConfiguration().get("booleanTrue", Boolean.class)).isTrue();
+        assertThat(ConfigurationProvider.getConfiguration().get("booleanFalse", Boolean.class)).isFalse();
+        assertThat(ConfigurationProvider.getConfiguration().get("foorBar", Boolean.class)).isFalse();
     }
 
     @Test
     public void testGetInteger() throws Exception {
-        assertEquals(Integer.MAX_VALUE, (int) ConfigurationProvider.getConfiguration().get("int", Integer.class));
+        assertThat(Integer.MAX_VALUE).isEqualTo((int) ConfigurationProvider.getConfiguration().get("int", Integer.class));
     }
 
     @Test
     public void testGetLong() throws Exception {
-        assertEquals(Long.MAX_VALUE, (long) ConfigurationProvider.getConfiguration().get("long", Long.class));
+        assertThat(Long.MAX_VALUE).isEqualTo((long) ConfigurationProvider.getConfiguration().get("long", Long.class));
     }
 
     @Test
     public void testGetDouble() throws Exception {
-        assertEquals(Double.MAX_VALUE, ConfigurationProvider.getConfiguration().get("double", Double.class), 0.0d);
+        assertThat(Double.MAX_VALUE).isEqualTo(ConfigurationProvider.getConfiguration().get("double", Double.class));
     }
 
     @Test
     public void testGetOrDefault() throws Exception {
-        assertEquals("StringIfThereWasNotAValueThere", ConfigurationProvider.getConfiguration().getOrDefault("nonexistant", "StringIfThereWasNotAValueThere"));
-        assertEquals("StringIfThereWasNotAValueThere", ConfigurationProvider.getConfiguration().getOrDefault("nonexistant", String.class, "StringIfThereWasNotAValueThere"));
+        assertThat("StringIfThereWasNotAValueThere").isEqualTo(ConfigurationProvider.getConfiguration().getOrDefault("nonexistant", "StringIfThereWasNotAValueThere"));
+        assertThat("StringIfThereWasNotAValueThere").isEqualTo(ConfigurationProvider.getConfiguration().getOrDefault("nonexistant", String.class, "StringIfThereWasNotAValueThere"));
     }
 
     @Test
     public void testToBuilder() throws Exception {
-        assertNotNull(ConfigurationProvider.getConfiguration().toBuilder());
+        assertThat(ConfigurationProvider.getConfiguration().toBuilder()).isNotNull();
     }
-    
+
     @Test
     public void testWith() throws Exception {
         ConfigOperator noop = (Configuration config) -> config;
-        assertNotNull(ConfigurationProvider.getConfiguration().with(noop));
+        assertThat(ConfigurationProvider.getConfiguration().with(noop)).isNotNull();
     }
-    
+
     @Test
     public void testQuery() throws Exception {
         ConfigQuery<String> stringQuery = (ConfigQuery) (Configuration config) -> config.get("String");
-        assertEquals("aStringValue", ConfigurationProvider.getConfiguration().query(stringQuery));
+        assertThat(ConfigurationProvider.getConfiguration().query(stringQuery)).isEqualTo("aStringValue");
     }
 }

--- a/code/api/src/test/java/org/apache/tamaya/TypeLiteralTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/TypeLiteralTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya;
 import java.lang.reflect.Type;
 import static org.apache.tamaya.TypeLiteral.getGenericInterfaceTypeParameters;
 import static org.apache.tamaya.TypeLiteral.getTypeParameters;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link TypeLiteral} class.
@@ -45,16 +44,16 @@ public class TypeLiteralTest {
     @Test
     public void test_constructor() {
         TypeLiteral<List<String>> listTypeLiteral = new TypeLiteral<List<String>>() { };
-        assertEquals(List.class, listTypeLiteral.getRawType());
-        assertEquals(String.class, TypeLiteral.getTypeParameters(listTypeLiteral.getType())[0]);
+        assertThat(listTypeLiteral.getRawType()).isEqualTo(List.class);
+        assertThat(TypeLiteral.getTypeParameters(listTypeLiteral.getType())[0]).isEqualTo(String.class);
     }
 
     @Test
     public void test_of() {
         class MyListClass extends ArrayList<String> { }
         TypeLiteral<MyListClass> listTypeLiteral = TypeLiteral.of(MyListClass.class);
-        assertEquals(MyListClass.class, listTypeLiteral.getRawType());
-        assertEquals(MyListClass.class, listTypeLiteral.getType());
+        assertThat(listTypeLiteral.getRawType()).isEqualTo(MyListClass.class);
+        assertThat(listTypeLiteral.getType()).isEqualTo(MyListClass.class);
     }
 
     @Test(expected = NullPointerException.class)
@@ -65,24 +64,24 @@ public class TypeLiteralTest {
     @Test
     public void test_getTypeParameters() {
         TypeLiteral<List<String>> listTypeLiteral = new TypeLiteral<List<String>>() { };
-        assertEquals(List.class, listTypeLiteral.getRawType());
-        assertEquals(String.class, TypeLiteral.getTypeParameters(listTypeLiteral.getType())[0]);
+        assertThat(listTypeLiteral.getRawType()).isEqualTo(List.class);
+        assertThat(TypeLiteral.getTypeParameters(listTypeLiteral.getType())[0]).isEqualTo(String.class);
     }
 
     @Test
     public void testGetTypeParametersNoGenerics() {
-        assertEquals(0, getTypeParameters(String.class).length);
+        assertThat(getTypeParameters(String.class).length).isEqualTo(0);
     }
 
     @Test
     public void test_getGenericInterfaceTypeParameter() {
         class MyListClass extends ArrayList<String> implements List<String> { }
-        assertEquals(String.class, getGenericInterfaceTypeParameters(MyListClass.class, List.class)[0]);
+        assertThat(getGenericInterfaceTypeParameters(MyListClass.class, List.class)[0]).isEqualTo(String.class);
     }
 
     @Test
     public void testGetGenericInterfaceTypeParameterNoGenerics() {
-        assertEquals(0, getGenericInterfaceTypeParameters(String.class, String.class).length);
+        assertThat(getGenericInterfaceTypeParameters(String.class, String.class).length).isEqualTo(0);
     }
 
     @Test(expected = NullPointerException.class)
@@ -107,7 +106,7 @@ public class TypeLiteralTest {
         class B extends A { };
         TypeLiteral<List<String>> checker = new TypeLiteral<List<String>>() { };
         Type t = checker.getDefinedType(B.class);
-        assertEquals(t.getTypeName(), "java.lang.String");
+        assertThat("java.lang.String").isEqualTo(t.getTypeName());
     }
 
     @Test(expected = RuntimeException.class)
@@ -125,13 +124,13 @@ public class TypeLiteralTest {
         TypeLiteral a = TypeLiteral.of(List.class);
         TypeLiteral b = TypeLiteral.of(List.class);
         TypeLiteral c = TypeLiteral.of(Map.class);
-        assertEquals(a.hashCode(), b.hashCode());
-        assertNotEquals(a.hashCode(), c.hashCode());
-        assertTrue(a.equals(a));
-        assertTrue(a.equals(b));
-        assertFalse(a.equals(null));
-        assertFalse(a.equals("SomeString"));
-        assertFalse(a.equals(c));
+        assertThat(b.hashCode()).isEqualTo(a.hashCode());
+        assertThat(a.hashCode()).isNotEqualTo(c.hashCode());
+        assertThat(a.equals(a)).isTrue();
+        assertThat(a.equals(b)).isTrue();
+        assertThat(a.equals(null)).isFalse();
+        assertThat(a.equals("SomeString")).isFalse();
+        assertThat(a.equals(c)).isFalse();
     }
 
 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationProviderSpiTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationProviderSpiTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.spi;
 
 import org.apache.tamaya.TestConfigurationProvider;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.mockito.Mockito;
 
 public class ConfigurationProviderSpiTest {
@@ -29,12 +29,12 @@ TestConfigurationProvider configProvider = new TestConfigurationProvider();
 
     @Test
     public void testIsConfigurationSettableByDefault(){
-        assertTrue(configProvider.isConfigurationSettable());
+        assertThat(configProvider.isConfigurationSettable()).isTrue();
     }
     
     @Test
     public void testIsConfigurationContextSettable(){
-        assertTrue(configProvider.isConfigurationContextSettable());
+        assertThat(configProvider.isConfigurationContextSettable()).isTrue();
     }    
     
     /**
@@ -44,13 +44,13 @@ TestConfigurationProvider configProvider = new TestConfigurationProvider();
     @Test
     public void testGetSetConfigurationContext() {
         ConfigurationContext currentContext = configProvider.getConfigurationContextFromInterface();
-        assertTrue(currentContext instanceof ConfigurationContext);
+        assertThat(currentContext instanceof ConfigurationContext).isTrue();
         ConfigurationContext newContext = Mockito.mock(ConfigurationContext.class);
         try{
             configProvider.setConfigurationContext(newContext);
             //The mocked TestConfigurationProvider doesn't set the context on the
             // inner Configuration object, as that's deprecated.
-            assertEquals(newContext, configProvider.getConfigurationContext());
+            assertThat(configProvider.getConfigurationContext()).isEqualTo(newContext);
         }finally{
             configProvider.setConfigurationContext(currentContext);
         }

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link ConversionContext}, created by atsticks on 20.08.16.
@@ -41,25 +41,25 @@ public class ConversionContextTest {
     @Test
     public void getSetKey() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("getKey", TypeLiteral.of(String.class)).build();
-        assertEquals("getKey", ctx.getKey());
+        assertThat(ctx.getKey()).isEqualTo("getKey");
         ctx = new ConversionContext.Builder("getKey", TypeLiteral.of(String.class)).setKey("setKey").build();
-        assertEquals("setKey", ctx.getKey());
+        assertThat(ctx.getKey()).isEqualTo("setKey");
     }
 
     @Test
     public void getSetTargetType() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("getTargetType", TypeLiteral.of(String.class)).build();
-        assertEquals(TypeLiteral.of(String.class), ctx.getTargetType());
+        assertThat(ctx.getTargetType()).isEqualTo(TypeLiteral.of(String.class));
         ctx = new ConversionContext.Builder("setTargetType", TypeLiteral.of(String.class)).setTargetType(TypeLiteral.of(Integer.class)).build();
-        assertEquals(TypeLiteral.of(Integer.class), ctx.getTargetType());
+        assertThat(ctx.getTargetType()).isEqualTo(TypeLiteral.of(Integer.class));
     }
 
     @Test
     public void getSetAnnotatedElement() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("getAnnotatedElement", TypeLiteral.of(List.class)).build();
-        assertNull(ctx.getAnnotatedElement());
+        assertThat(ctx.getAnnotatedElement()).isNull();
         ctx = new ConversionContext.Builder(TypeLiteral.of(List.class)).setAnnotatedElement(MyAnnotatedElement).build();
-        assertEquals(MyAnnotatedElement, ctx.getAnnotatedElement());
+        assertThat(ctx.getAnnotatedElement()).isEqualTo(MyAnnotatedElement);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class ConversionContextTest {
         Configuration config = new MyConfiguration();
         ConversionContext ctx = new ConversionContext.Builder("testConfiguration", TypeLiteral.of(List.class))
                 .setConfiguration(config).build();
-        assertEquals(config, ctx.getConfiguration());
+        assertThat(ctx.getConfiguration()).isEqualTo(config);
     }
 
     @Test
@@ -81,23 +81,23 @@ public class ConversionContextTest {
 
         ConversionContext ctx = new ConversionContext.Builder("getSupportedFormats", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, writeable.get(0), writeable.get(1)).build();
-        assertTrue(ctx.getSupportedFormats().containsAll(readable));
-        assertTrue(ctx.getSupportedFormats().indexOf(readable.get(0))
-                < ctx.getSupportedFormats().indexOf(readable.get(1)));
+        assertThat(ctx.getSupportedFormats().containsAll(readable)).isTrue();
+        assertThat(ctx.getSupportedFormats().indexOf(readable.get(0))
+                < ctx.getSupportedFormats().indexOf(readable.get(1))).isTrue();
 
         ctx = new ConversionContext.Builder(TypeLiteral.of(List.class)).build();
-        assertTrue(ctx.getSupportedFormats().isEmpty());
+        assertThat(ctx.getSupportedFormats().isEmpty()).isTrue();
         ctx.addSupportedFormats(MyConverter.class, writeable.get(0), writeable.get(1));
-        assertTrue(ctx.getSupportedFormats().containsAll(readable));
-        assertTrue(ctx.getSupportedFormats().indexOf(readable.get(0))
-                < ctx.getSupportedFormats().indexOf(readable.get(1)));
+        assertThat(ctx.getSupportedFormats().containsAll(readable)).isTrue();
+        assertThat(ctx.getSupportedFormats().indexOf(readable.get(0))
+                < ctx.getSupportedFormats().indexOf(readable.get(1))).isTrue();
     }
 
     @Test
     public void testToString() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("toString", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy").build();
-        assertEquals("ConversionContext{configuration=null, key='toString', targetType=TypeLiteral{type=interface java.util.List}, annotatedElement=null, supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]}", ctx.toString());
+        assertThat(ctx.toString()).isEqualTo("ConversionContext{configuration=null, key='toString', targetType=TypeLiteral{type=interface java.util.List}, annotatedElement=null, supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]}");
     }
 
     @Test
@@ -105,7 +105,7 @@ public class ConversionContextTest {
         ConfigurationContext context = new MyConfigurationContext();
         ConversionContext ctx = new ConversionContext.Builder("getConfigurationContext", TypeLiteral.of(List.class))
                 .setConfigurationContext(context).build();
-        assertEquals(context, ctx.getConfigurationContext());
+        assertThat(ctx.getConfigurationContext()).isEqualTo(context);
     }
 
     private static final AnnotatedElement MyAnnotatedElement = new AnnotatedElement() {

--- a/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link FilterContext}.
@@ -65,16 +65,16 @@ public class FilterContextTest {
         PropertyValue val = PropertyValue.of("getKey", "v", "");
         FilterContext ctx = new FilterContext(val,
                 new HashMap<String,PropertyValue>(), new TestConfigContext());
-        assertEquals(val, ctx.getProperty());
+        assertThat(ctx.getProperty()).isEqualTo(val);
     }
 
     @Test
     public void isSinglePropertyScoped() throws Exception {
         PropertyValue val = PropertyValue.of("isSinglePropertyScoped", "v", "");
         FilterContext ctx = new FilterContext(val, new HashMap<String,PropertyValue>(), new TestConfigContext());
-        assertEquals(false, ctx.isSinglePropertyScoped());
+        assertThat(ctx.isSinglePropertyScoped()).isEqualTo(false);
         ctx = new FilterContext(val, new TestConfigContext());
-        assertEquals(true, ctx.isSinglePropertyScoped());
+        assertThat(ctx.isSinglePropertyScoped()).isEqualTo(true);
     }
 
     @Test
@@ -85,8 +85,8 @@ public class FilterContextTest {
         }
         PropertyValue val = PropertyValue.of("getConfigEntries", "v", "");
         FilterContext ctx = new FilterContext(val, config, new TestConfigContext());
-        assertEquals(config, ctx.getConfigEntries());
-        assertTrue(config != ctx.getConfigEntries());
+        assertThat(ctx.getConfigEntries()).isEqualTo(config);
+        assertThat(config != ctx.getConfigEntries()).isTrue();
     }
 
     @Test
@@ -99,12 +99,12 @@ public class FilterContextTest {
         FilterContext ctx = new FilterContext(val, config, new TestConfigContext());
         String toString = ctx.toString();
 
-        assertNotNull(toString);
-        assertTrue(toString.contains("FilterContext{value='PropertyValue{key='testToString', value='val', " +
-                                     "source='mySource'}', configEntries=["));
-        assertTrue(toString.contains("key-0"));
-        assertTrue(toString.contains("key-1"));
-        assertTrue(toString.endsWith("}"));
+        assertThat(toString).isNotNull();
+        assertThat(toString.contains("FilterContext{value='PropertyValue{key='testToString', value='val', " +
+                                     "source='mySource'}', configEntries=[")).isTrue();
+        assertThat(toString.contains("key-0")).isTrue();
+        assertThat(toString.contains("key-1")).isTrue();
+        assertThat(toString.endsWith("}")).isTrue();
     }
 
     private static class TestConfigContext implements ConfigurationContext{

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
@@ -19,7 +19,7 @@
 package org.apache.tamaya.spi;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class PropertySourceProviderTest {
     
@@ -29,7 +29,7 @@ public class PropertySourceProviderTest {
     @Test
     public void testEmptySourceProvider() {
         PropertySourceProvider instance = PropertySourceProvider.EMPTY;
-        assertTrue(instance.getPropertySources().isEmpty());
-        assertEquals("PropertySourceProvider(empty)", instance.toString());
+        assertThat(instance.getPropertySources().isEmpty()).isTrue();
+        assertThat(instance.toString()).isEqualTo("PropertySourceProvider(empty)");
     }
 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.spi;
 
 import java.util.Map;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class PropertySourceTest {
 
@@ -31,12 +31,12 @@ public class PropertySourceTest {
     @Test
     public void testEmptySource() {
         PropertySource instance = PropertySource.EMPTY;
-        assertEquals(Integer.MIN_VALUE, instance.getOrdinal());
-        assertEquals("<empty>", instance.getName());
-        assertNull(instance.get("key"));
-        assertTrue(instance.getProperties().isEmpty());
-        assertFalse(instance.isScannable());
-        assertEquals("PropertySource.EMPTY", instance.toString());
+        assertThat(instance.getOrdinal()).isEqualTo(Integer.MIN_VALUE);
+        assertThat(instance.getName()).isEqualTo("<empty>");
+        assertThat(instance.get("key")).isNull();
+        assertThat(instance.getProperties().isEmpty()).isTrue();
+        assertThat(instance.isScannable()).isFalse();
+        assertThat(instance.toString()).isEqualTo("PropertySource.EMPTY");
         
     }
 
@@ -46,7 +46,7 @@ public class PropertySourceTest {
     @Test
     public void testIsScannableByDefault() {
         PropertySource instance = new PropertySourceImpl();
-        assertEquals(true, instance.isScannable());
+        assertThat(instance.isScannable()).isEqualTo(true);
     }
 
     public class PropertySourceImpl implements PropertySource {

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueBuilderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueBuilderTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tamaya.spi;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -121,27 +121,27 @@ public class PropertyValueBuilderTest {
     public void testKey() throws Exception {
         PropertyValueBuilder b = new PropertyValueBuilder("k", "testKey").setValue("v");
         PropertyValue val = b.build();
-        assertEquals(val.getKey(),"k");
-        assertEquals(val.getValue(),"v");
-        assertNull(val.getMetaEntries().get("k"));
+        assertThat("k").isEqualTo(val.getKey());
+        assertThat("v").isEqualTo(val.getValue());
+        assertThat(val.getMetaEntries().get("k")).isNull();
     }
     
     @Test
     public void testSetKey() {
         PropertyValueBuilder b = new PropertyValueBuilder("k", "testSetKey").setKey("key");
         PropertyValue val = b.build();
-        assertEquals(val.getKey(),"key");
+        assertThat("key").isEqualTo(val.getKey());
     }
 
     @Test
     public void testSource() throws Exception {
         PropertyValueBuilder b = new PropertyValueBuilder("k", "testSource").setValue("v");
         PropertyValue val = b.build();
-        assertEquals(val.getSource(),"testSource");
+        assertThat("testSource").isEqualTo(val.getSource());
         
         PropertyValueBuilder b2 = b.setSource("differentSource");
         val = b2.build();
-        assertEquals(val.getSource(),"differentSource");
+        assertThat("differentSource").isEqualTo(val.getSource());
     }
 
     @Test(expected=NullPointerException.class)
@@ -158,31 +158,31 @@ public class PropertyValueBuilderTest {
                 .setValue("v")
                 .addMetaEntry("k", "v2")
                 .setMetaEntries(meta).build();
-        assertEquals("v", pv.getValue());
-        assertEquals("k", pv.getKey());
-        assertNull(pv.getMetaEntry("k"));
-        assertEquals("testGetKey", pv.getSource());
-        assertEquals(2, pv.getMetaEntries().size());
-        assertEquals("2", pv.getMetaEntry("1"));
-        assertEquals("b", pv.getMetaEntry("a"));
+        assertThat(pv.getValue()).isEqualTo("v");
+        assertThat(pv.getKey()).isEqualTo("k");
+        assertThat(pv.getMetaEntry("k")).isNull();
+        assertThat(pv.getSource()).isEqualTo("testGetKey");
+        assertThat(pv.getMetaEntries()).hasSize(2);
+        assertThat(pv.getMetaEntry("1")).isEqualTo("2");
+        assertThat(pv.getMetaEntry("a")).isEqualTo("b");
     }
 
     @Test
     public void testGetKey() throws Exception {
         PropertyValue pv = PropertyValue.builder("k", "testGetKey").setValue("v").build();
-        assertEquals("k", pv.getKey());
+        assertThat(pv.getKey()).isEqualTo("k");
     }
 
     @Test
     public void testGetValue1() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", "testGetValue");
-        assertEquals("v", pv.getValue());
+        assertThat(pv.getValue()).isEqualTo("v");
     }
 
     @Test
     public void testGetValue2() throws Exception {
         PropertyValue pv = PropertyValue.builder("k", "testGetValue").setValue("v").build();
-        assertEquals("v", pv.getValue());
+        assertThat(pv.getValue()).isEqualTo("v");
     }
 
     @Test(expected = NullPointerException.class)
@@ -197,8 +197,8 @@ public class PropertyValueBuilderTest {
                 .addMetaEntry("k", "v2")
                 .addMetaEntry("k2", "v22")
                 .removeMetaEntry("k").build();
-        assertEquals("v22", pv.getMetaEntry("k2"));
-        assertNull(pv.getMetaEntry("k"));
+        assertThat(pv.getMetaEntry("k2")).isEqualTo("v22");
+        assertThat(pv.getMetaEntry("k")).isNull();
     }
 
     @Test(expected=NullPointerException.class)
@@ -215,8 +215,8 @@ public class PropertyValueBuilderTest {
                 .setValue("v")
                 .setMetaEntries(meta);
         PropertyValue pv = b.build();
-        assertEquals(meta, b.getMetaEntries());
-        assertEquals(meta, pv.getMetaEntries());
+        assertThat(b.getMetaEntries()).isEqualTo(meta);
+        assertThat(pv.getMetaEntries()).isEqualTo(meta);
     }
 
     @Test
@@ -231,10 +231,10 @@ public class PropertyValueBuilderTest {
         context.remove("y");
         b.setMetaEntries(context);
         PropertyValue contextData = b.build();
-        assertEquals(contextData.getMetaEntries().size(), context.size());
-        assertEquals(contextData.getMetaEntry("source"), "testSetContextData");
-        assertNotNull(contextData.getMetaEntry("ts"));
-        assertNull(contextData.getMetaEntry("y"));
+        assertThat(context.size()).isEqualTo(contextData.getMetaEntries().size());
+        assertThat("testSetContextData").isEqualTo(contextData.getMetaEntry("source"));
+        assertThat(contextData.getMetaEntry("ts")).isNotNull();
+        assertThat(contextData.getMetaEntry("y")).isNull();
     }
 
     @Test
@@ -244,9 +244,9 @@ public class PropertyValueBuilderTest {
         b.addMetaEntry("y", "yValue");
         b.addMetaEntry("y", "y2");
         PropertyValue contextData = b.build();
-        assertEquals(contextData.getMetaEntries().size(), 2);
-        assertNotNull(contextData.getMetaEntry("ts"));
-        assertEquals(contextData.getMetaEntry("y"), "y2");
+        assertThat(2).isEqualTo(contextData.getMetaEntries().size());
+        assertThat(contextData.getMetaEntry("ts")).isNotNull();
+        assertThat("y2").isEqualTo(contextData.getMetaEntry("y"));
     }
     
     @Test
@@ -257,11 +257,11 @@ public class PropertyValueBuilderTest {
                 .addMetaEntry("somethingelse", "othervalue")
                 .mapKey("mappedkey");
         PropertyValue pv = b.build();     
-        assertEquals("mappedkey", pv.getKey());
-        assertEquals("value", pv.getValue());
-        assertEquals(2, pv.getMetaEntries().size());
-        assertEquals("mappedvalue", pv.getMetaEntry("_mappedkey.AndThenSome"));
-        assertEquals("othervalue", pv.getMetaEntry("somethingelse"));
+        assertThat(pv.getKey()).isEqualTo("mappedkey");
+        assertThat(pv.getValue()).isEqualTo("value");
+        assertThat(pv.getMetaEntries()).hasSize(2);
+        assertThat(pv.getMetaEntry("_mappedkey.AndThenSome")).isEqualTo("mappedvalue");
+        assertThat(pv.getMetaEntry("somethingelse")).isEqualTo("othervalue");
     }
     
     @Test
@@ -269,7 +269,7 @@ public class PropertyValueBuilderTest {
         PropertyValueBuilder b = new PropertyValueBuilder("k")
                 .setValue("v")
                 .addMetaEntry("metak", "metav");
-        assertEquals("PropertyValueBuilder{key='k'value='v', metaEntries={metak=metav}}", b.toString());
+        assertThat(b.toString()).isEqualTo("PropertyValueBuilder{key='k'value='v', metaEntries={metak=metav}}");
     }
 
 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 @SuppressWarnings("unchecked")
 public class PropertyValueTest {
@@ -56,7 +56,7 @@ public class PropertyValueTest {
 
     @Test
     public void testOf(){
-        assertNotNull(PropertyValue.of("k", "v", "testGetKey"));
+        assertThat(PropertyValue.of("k", "v", "testGetKey")).isNotNull();
     }
 
     @Test(expected = NullPointerException.class)
@@ -71,79 +71,69 @@ public class PropertyValueTest {
 
     @Test
     public void testHashCode(){
-        assertEquals(PropertyValue.of("k", "v", "testGetKey").hashCode(),
-                PropertyValue.of("k", "v", "testGetKey").hashCode());
-        assertNotSame(PropertyValue.of("k", "v", "testGetKey").hashCode(),
-                PropertyValue.of("k1", "v", "testGetKey").hashCode());
-        assertNotSame(PropertyValue.of("k", "v", "testGetKey").hashCode(),
-                PropertyValue.of("k", "v1", "testGetKey").hashCode());
-        assertNotSame(PropertyValue.of("k", "v", "1").hashCode(),
-                PropertyValue.of("k", "v", "2").hashCode());
+        assertThat(PropertyValue.of("k", "v", "testGetKey").hashCode()).isEqualTo(PropertyValue.of("k", "v", "testGetKey").hashCode());
+        assertThat(PropertyValue.of("k", "v", "testGetKey").hashCode()).isNotSameAs(PropertyValue.of("k1", "v", "testGetKey").hashCode());
+        assertThat(PropertyValue.of("k", "v", "testGetKey").hashCode()).isNotSameAs(PropertyValue.of("k", "v1", "testGetKey").hashCode());
+        assertThat(PropertyValue.of("k", "v", "1").hashCode()).isNotSameAs(PropertyValue.of("k", "v", "2").hashCode());
     }
 
     @Test
     public void testEquals(){
-        assertEquals(PropertyValue.of("k", "v", "testEquals"),
-                PropertyValue.of("k", "v", "testEquals"));
-        assertNotSame(PropertyValue.of("k2", "v", "testEquals"),
-                PropertyValue.of("k", "v", "testEquals"));
-        assertNotSame(PropertyValue.of("k", "v", "testEquals"),
-                PropertyValue.of("k", "v2", "testEquals"));
-        assertNotSame(PropertyValue.of("k", "v", "testEquals"),
-                PropertyValue.of("k", "v", "testEquals2"));
+        assertThat(PropertyValue.of("k", "v", "testEquals")).isEqualTo(PropertyValue.of("k", "v", "testEquals"));
+        assertThat(PropertyValue.of("k2", "v", "testEquals")).isNotSameAs(PropertyValue.of("k", "v", "testEquals"));
+        assertThat(PropertyValue.of("k", "v", "testEquals")).isNotSameAs(PropertyValue.of("k", "v2", "testEquals"));
+        assertThat(PropertyValue.of("k", "v", "testEquals")).isNotSameAs(PropertyValue.of("k", "v", "testEquals2"));
     }
-
+        
     @Test
     public void testBuilder(){
-        assertNotNull(PropertyValue.builder("k", "testGetKey"));
-        assertEquals(PropertyValue.of("k", "v", "testEquals"),
-                PropertyValue.builder("k", "testEquals").setValue("v").build());
+        assertThat(PropertyValue.builder("k", "testGetKey")).isNotNull();
+        assertThat(PropertyValue.of("k", "v", "testEquals")).isEqualTo(PropertyValue.builder("k", "testEquals").setValue("v").build());
     }
 
     @Test
     public void testToBuilder(){
-        assertNotNull(PropertyValue.of("k", "v", "testGetKey").toBuilder());
+        assertThat(PropertyValue.of("k", "v", "testGetKey").toBuilder()).isNotNull();
         // round-trip
         PropertyValue val = PropertyValue.of("k", "v", "testGetKey");
-        assertEquals(val,
-                val.toBuilder().build());
+        assertThat(val).isEqualTo(val.toBuilder().build());
     }
 
     @Test
     public void testGetKey() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", "testGetKey");
-        assertEquals("k", pv.getKey());
+        assertThat(pv.getKey()).isEqualTo("k");
     }
 
     @Test
     public void testGetValue() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", "testGetValue");
-        assertEquals("v", pv.getValue());
+        assertThat(pv.getValue()).isEqualTo("v");
     }
 
     @Test
     public void testGetSource() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", "testGetSource");
-        assertEquals("testGetSource", pv.getSource());
+        assertThat(pv.getSource()).isEqualTo("testGetSource");
         pv = PropertyValue.of("k", "v", "testGetSource");
-        assertEquals("testGetSource", pv.getSource());
+        assertThat(pv.getSource()).isEqualTo("testGetSource");
     }
 
     @Test
     public void testGetMetaEntry() throws Exception {
         PropertyValue pv = PropertyValue.builder("k", "testGetMetaEntry").setValue("v")
                 .addMetaEntry("k", "v2").build();
-        assertEquals("v", pv.getValue());
-        assertEquals("k", pv.getKey());
-        assertEquals("v2", pv.getMetaEntry("k"));
-        assertEquals("testGetMetaEntry", pv.getSource());
+        assertThat(pv.getValue()).isEqualTo("v");
+        assertThat(pv.getKey()).isEqualTo("k");
+        assertThat(pv.getMetaEntry("k")).isEqualTo("v2");
+        assertThat(pv.getSource()).isEqualTo("testGetMetaEntry");
     }
 
     @Test
     public void testGetMetaEntries() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", "testGetMetaEntries");
-        assertNotNull(pv.getMetaEntries());
-        assertTrue(pv.getMetaEntries().isEmpty());
+        assertThat(pv.getMetaEntries()).isNotNull();
+        assertThat(pv.getMetaEntries().isEmpty()).isTrue();
     }
 
     @Test
@@ -152,16 +142,16 @@ public class PropertyValueTest {
         map.put("a", "1");
         map.put("b", "2");
         Map<String,PropertyValue> result = PropertyValue.map(map, "source1");
-        assertNotNull(result);
-        assertEquals(map.size(), result.size());
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(map.size());
 
         for (Map.Entry<String,String>en:map.entrySet()) {
             PropertyValue val = result.get(en.getKey());
-            assertNotNull(val);
-            assertEquals(val.getKey(), en.getKey());
-            assertEquals(val.getValue(), en.getValue());
-            assertEquals(val.getSource(), "source1");
-            assertTrue(val.getMetaEntries().isEmpty());
+            assertThat(val).isNotNull();
+            assertThat(en.getKey()).isEqualTo(val.getKey());
+            assertThat(en.getValue()).isEqualTo(val.getValue());
+            assertThat("source1").isEqualTo(val.getSource());
+            assertThat(val.getMetaEntries().isEmpty()).isTrue();
         }
     }
 
@@ -174,15 +164,15 @@ public class PropertyValueTest {
         map.put("m1", "n1");
         map.put("m2", "n2");
         Map<String,PropertyValue> result = PropertyValue.map(map, "source1", meta);
-        assertNotNull(result);
-        assertEquals(map.size(), result.size());
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(map.size());
         for(Map.Entry<String,String>en:map.entrySet()){
             PropertyValue val = result.get(en.getKey());
-            assertNotNull(val);
-            assertEquals(val.getKey(), en.getKey());
-            assertEquals(val.getValue(), en.getValue());
-            assertEquals(val.getSource(), "source1");
-            assertEquals(val.getMetaEntries(), meta);
+            assertThat(val).isNotNull();
+            assertThat(en.getKey()).isEqualTo(val.getKey());
+            assertThat(en.getValue()).isEqualTo(val.getValue());
+            assertThat("source1").isEqualTo(val.getSource());
+            assertThat(meta).isEqualTo(val.getMetaEntries());
         }
     }
 

--- a/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextManagerTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextManagerTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Additional tests for {@link ServiceContextManager}, created by atsticks on 20.08.16.
@@ -39,12 +39,12 @@ public class ServiceContextManagerTest {
         try {
             MyServiceContext mine = new MyServiceContext();
             ServiceContextManager.set(mine);
-            assertTrue(ServiceContextManager.getServiceContext() == mine);
+            assertThat(ServiceContextManager.getServiceContext() == mine).isTrue();
             ServiceContextManager.set(mine);
-            assertTrue(ServiceContextManager.getServiceContext() == mine);
+            assertThat(ServiceContextManager.getServiceContext() == mine).isTrue();
         } finally {
             ServiceContextManager.set(prev);
-            assertTrue(ServiceContextManager.getServiceContext() == prev);
+            assertThat(ServiceContextManager.getServiceContext() == prev).isTrue();
         }
 
     }

--- a/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
@@ -18,11 +18,7 @@
  */
 package org.apache.tamaya.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -76,38 +72,38 @@ public class ServiceContextTest {
 
     @Test
     public void testOrdinal() throws Exception {
-        assertEquals(1, serviceContext.ordinal());
+        assertThat(serviceContext.ordinal()).isEqualTo(1);
     }
 
     @Test
     public void testgetService() throws Exception {
-        assertEquals("ServiceContextTest", serviceContext.getService(String.class));
-        assertNull(serviceContext.getService(Integer.class));
+        assertThat(serviceContext.getService(String.class)).isEqualTo("ServiceContextTest");
+        assertThat(serviceContext.getService(Integer.class)).isNull();
     }
 
     @Test
     public void testGetService() throws Exception {
         String service = serviceContext.getService(String.class);
-        assertNotNull(service);
-        assertEquals("ServiceContextTest", service);
+        assertThat(service).isNotNull();
+        assertThat(service).isEqualTo("ServiceContextTest");
         Integer intService = serviceContext.getService(Integer.class);
-        assertNull(intService);
+        assertThat(intService).isNull();
     }
 
     @Test
     public void testGetServices() throws Exception {
         Collection<String> services = serviceContext.getServices(String.class);
-        assertNotNull(services);
-        assertFalse(services.isEmpty());
-        assertEquals("ServiceContextTest", services.iterator().next());
+        assertThat(services).isNotNull();
+        assertThat(services.isEmpty()).isFalse();
+        assertThat(services.iterator().next()).isEqualTo("ServiceContextTest");
         List<Integer> intServices = serviceContext.getServices(Integer.class);
-        assertNotNull(intServices);
-        assertTrue(intServices.isEmpty());
+        assertThat(intServices).isNotNull();
+        assertThat(intServices.isEmpty()).isTrue();
     }
 
     @Test
     public void testGetInstance() throws Exception {
-        assertNotNull(ServiceContextManager.getServiceContext());
+        assertThat(ServiceContextManager.getServiceContext()).isNotNull();
     }
 
 }

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -49,10 +49,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <scope>provided</scope>

--- a/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
@@ -30,7 +30,7 @@ import sun.security.krb5.Config;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link ConfigurationBuilder} by atsticks on 06.09.16.
@@ -44,7 +44,7 @@ public class ConfigurationBuilderTest {
         Configuration cfg = ConfigurationProvider.getConfiguration();
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder()
                 .setConfiguration(cfg);
-        assertEquals(cfg, b.build());
+        assertThat(b.build()).isEqualTo(cfg);
     }
 
     @Test
@@ -53,19 +53,19 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new TestPropertySource("addPropertySources_Array", 1);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(testPS2, testPropertySource);
         cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
-        assertEquals(cfg.getContext().getPropertySources().get(1).getName(), "TestPropertySource");
-        assertEquals(cfg.getContext().getPropertySources().get(0).getName(), "addPropertySources_Array");
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Array").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
     }
 
     @Test
@@ -74,21 +74,21 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPropertySource, testPS2}));
         Configuration cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
-        assertEquals(cfg.getContext().getPropertySources().get(0).getName(), "TestPropertySource");
-        assertEquals(cfg.getContext().getPropertySources().get(1).getName(), "addPropertySources_Collection");
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new TestPropertySource("addPropertySources_Collection", 1);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPS2, testPropertySource}));
         cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
-        assertEquals(cfg.getContext().getPropertySources().get(1).getName(), "TestPropertySource");
-        assertEquals(cfg.getContext().getPropertySources().get(0).getName(), "addPropertySources_Collection");
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
     }
 
     @Test
@@ -97,16 +97,16 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
-        assertFalse(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
-        assertEquals(1, cfg.getContext().getPropertySources().size());
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(1);
     }
 
     @Test
@@ -115,16 +115,16 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertEquals(2, cfg.getContext().getPropertySources().size());
-        assertTrue(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
-        assertEquals(1, cfg.getContext().getPropertySources().size());
-        assertFalse(cfg.getContext().getPropertySources().contains(testPropertySource));
-        assertTrue(cfg.getContext().getPropertySources().contains(testPS2));
+        assertThat(cfg.getContext().getPropertySources()).hasSize(1);
+        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -135,13 +135,13 @@ public class ConfigurationBuilderTest {
         b.addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -152,13 +152,13 @@ public class ConfigurationBuilderTest {
         b.addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -169,17 +169,17 @@ public class ConfigurationBuilderTest {
                 .addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyFilters(filter1, filter2);
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
     }
 
     @Test
@@ -190,17 +190,17 @@ public class ConfigurationBuilderTest {
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
     }
 
     @Test
@@ -211,12 +211,12 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
     }
 
     @Test
@@ -228,13 +228,13 @@ public class ConfigurationBuilderTest {
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
     }
 
     @Test
@@ -245,15 +245,15 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.removePropertyConverters(TypeLiteral.of(String.class), converter);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
 
@@ -265,15 +265,15 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = ConfigurationProvider.getConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         cfg = b.build();
         ctx = cfg.getContext();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -283,7 +283,7 @@ public class ConfigurationBuilderTest {
                 .setPropertyValueCombinationPolicy(combPol);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(ctx.getPropertyValueCombinationPolicy(), combPol);
+        assertThat(combPol).isEqualTo(ctx.getPropertyValueCombinationPolicy());
     }
 
     @Test
@@ -296,14 +296,14 @@ public class ConfigurationBuilderTest {
         b.addPropertySources(propertySources);
         b.increasePriority(propertySources[propertySources.length-1]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.increasePriority(propertySources[propertySources.length-2]);
         for(int i=0;i<propertySources.length-2;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length-1], b.getPropertySources().get(propertySources.length-2));
-        assertEquals(propertySources[propertySources.length-2], b.getPropertySources().get(propertySources.length-1));
+        assertThat(b.getPropertySources().get(propertySources.length-2)).isEqualTo(propertySources[propertySources.length-1]);
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[propertySources.length-2]);
     }
 
     @Test
@@ -316,14 +316,14 @@ public class ConfigurationBuilderTest {
         b.addPropertySources(propertySources);
         b.decreasePriority(propertySources[0]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.decreasePriority(propertySources[1]);
         for(int i=2;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
     }
 
     @Test
@@ -338,16 +338,16 @@ public class ConfigurationBuilderTest {
         // test
         b.lowestPriority(propertySources[0]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.lowestPriority(propertySources[1]);
         for(int i=2;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         b.lowestPriority(propertySources[5]);
-        assertEquals(propertySources[5], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[5]);
     }
 
     @Test
@@ -362,16 +362,16 @@ public class ConfigurationBuilderTest {
         // test
         b.highestPriority(propertySources[propertySources.length-1]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.highestPriority(propertySources[propertySources.length-2]);
         for(int i=0;i<propertySources.length-2;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length-2], b.getPropertySources().get(propertySources.length-1));
-        assertEquals(propertySources[propertySources.length-1], b.getPropertySources().get(propertySources.length-2));
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[propertySources.length-2]);
+        assertThat(b.getPropertySources().get(propertySources.length-2)).isEqualTo(propertySources[propertySources.length-1]);
         b.highestPriority(propertySources[5]);
-        assertEquals(propertySources[5], b.getPropertySources().get(propertySources.length-1));
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[5]);
     }
 
     @Test
@@ -388,7 +388,7 @@ public class ConfigurationBuilderTest {
         b.sortPropertySources(psComp);
         Arrays.sort(propertySources, psComp);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
     }
 
@@ -406,7 +406,7 @@ public class ConfigurationBuilderTest {
         b.sortPropertyFilter(pfComp);
         Arrays.sort(propertyFilters, pfComp);
         for(int i=0;i<propertyFilters.length;i++){
-            assertEquals(propertyFilters[i], b.getPropertyFilters().get(i));
+            assertThat(b.getPropertyFilters().get(i)).isEqualTo(propertyFilters[i]);
         }
     }
 
@@ -415,26 +415,26 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder();
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertNotNull(ctx);
-        assertTrue(ctx.getPropertySources().isEmpty());
-        assertTrue(ctx.getPropertyFilters().isEmpty());
+        assertThat(ctx).isNotNull();
+        assertThat(ctx.getPropertySources().isEmpty()).isTrue();
+        assertThat(ctx.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
     public void testRemoveAllFilters() throws Exception {
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder();
         b.addPropertyFilters((value, context) -> value.toBuilder().setValue(toString() + " - ").build());
-        assertFalse(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isFalse();
         b.removePropertyFilters(b.getPropertyFilters());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
     public void testRemoveAllSources() throws Exception {
         ConfigurationBuilder b = ConfigurationProvider.getConfigurationBuilder();
         b.addPropertySources(new TestPropertySource());
-        assertFalse(b.getPropertySources().isEmpty());
+        assertThat(b.getPropertySources().isEmpty()).isFalse();
         b.removePropertySources(b.getPropertySources());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/ConfigurationContextBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/ConfigurationContextBuilderTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link ConfigurationContextBuilder} by atsticks on 06.09.16.
@@ -41,7 +41,7 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContext context = ConfigurationProvider.getConfiguration().getContext();
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .setContext(context);
-        assertEquals(context, b.build());
+        assertThat(b.build()).isEqualTo(context);
     }
 
     @Test
@@ -50,19 +50,19 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new TestPropertySource("addPropertySources_Array", 1);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(testPS2, testPropertySource);
         ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertEquals(ctx.getPropertySources().get(1).getName(), "TestPropertySource");
-        assertEquals(ctx.getPropertySources().get(0).getName(), "addPropertySources_Array");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(ctx.getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Array").isEqualTo(ctx.getPropertySources().get(0).getName());
     }
 
     @Test
@@ -71,21 +71,21 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPropertySource, testPS2}));
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertEquals(ctx.getPropertySources().get(0).getName(), "TestPropertySource");
-        assertEquals(ctx.getPropertySources().get(1).getName(), "addPropertySources_Collection");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(ctx.getPropertySources().get(0).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(ctx.getPropertySources().get(1).getName());
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new TestPropertySource("addPropertySources_Collection", 1);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPS2, testPropertySource}));
         ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertEquals(ctx.getPropertySources().get(1).getName(), "TestPropertySource");
-        assertEquals(ctx.getPropertySources().get(0).getName(), "addPropertySources_Collection");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat("TestPropertySource").isEqualTo(ctx.getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(ctx.getPropertySources().get(0).getName());
     }
 
     @Test
@@ -94,16 +94,16 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         ctx = b.build();
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertEquals(1, ctx.getPropertySources().size());
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(1);
     }
 
     @Test
@@ -112,16 +112,16 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         ctx = b.build();
-        assertEquals(1, ctx.getPropertySources().size());
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(1);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -131,13 +131,13 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertyFilters(filter1, filter2);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -147,13 +147,13 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -163,16 +163,16 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyFilters(filter1, filter2);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyFilters(filter1, filter2);
         b.removePropertyFilters(filter1);
         ctx = b.build();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
     }
 
     @Test
@@ -182,16 +182,16 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         b.removePropertyFilters(filter1);
         ctx = b.build();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
     }
 
     @Test
@@ -201,12 +201,12 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
     }
 
     @Test
@@ -217,13 +217,13 @@ public class ConfigurationContextBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
     }
 
     @Test
@@ -233,14 +233,14 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.removePropertyConverters(TypeLiteral.of(String.class), converter);
         ctx = b.build();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -250,14 +250,14 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = ConfigurationProvider.getConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         ctx = b.build();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -266,7 +266,7 @@ public class ConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder()
                 .setPropertyValueCombinationPolicy(combPol);
         ConfigurationContext ctx = b.build();
-        assertEquals(ctx.getPropertyValueCombinationPolicy(), combPol);
+        assertThat(combPol).isEqualTo(ctx.getPropertyValueCombinationPolicy());
     }
 
     @Test
@@ -279,14 +279,14 @@ public class ConfigurationContextBuilderTest {
         b.addPropertySources(propertySources);
         b.increasePriority(propertySources[propertySources.length-1]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.increasePriority(propertySources[propertySources.length-2]);
         for(int i=0;i<propertySources.length-2;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length-1], b.getPropertySources().get(propertySources.length-2));
-        assertEquals(propertySources[propertySources.length-2], b.getPropertySources().get(propertySources.length-1));
+        assertThat(b.getPropertySources().get(propertySources.length-2)).isEqualTo(propertySources[propertySources.length-1]);
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[propertySources.length-2]);
     }
 
     @Test
@@ -299,14 +299,14 @@ public class ConfigurationContextBuilderTest {
         b.addPropertySources(propertySources);
         b.decreasePriority(propertySources[0]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.decreasePriority(propertySources[1]);
         for(int i=2;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
     }
 
     @Test
@@ -321,16 +321,16 @@ public class ConfigurationContextBuilderTest {
         // test
         b.lowestPriority(propertySources[0]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.lowestPriority(propertySources[1]);
         for(int i=2;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         b.lowestPriority(propertySources[5]);
-        assertEquals(propertySources[5], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[5]);
     }
 
     @Test
@@ -345,16 +345,16 @@ public class ConfigurationContextBuilderTest {
         // test
         b.highestPriority(propertySources[propertySources.length-1]);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.highestPriority(propertySources[propertySources.length-2]);
         for(int i=0;i<propertySources.length-2;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length-2], b.getPropertySources().get(propertySources.length-1));
-        assertEquals(propertySources[propertySources.length-1], b.getPropertySources().get(propertySources.length-2));
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[propertySources.length-2]);
+        assertThat(b.getPropertySources().get(propertySources.length-2)).isEqualTo(propertySources[propertySources.length-1]);
         b.highestPriority(propertySources[5]);
-        assertEquals(propertySources[5], b.getPropertySources().get(propertySources.length-1));
+        assertThat(b.getPropertySources().get(propertySources.length-1)).isEqualTo(propertySources[5]);
     }
 
     @Test
@@ -371,7 +371,7 @@ public class ConfigurationContextBuilderTest {
         b.sortPropertySources(psComp);
         Arrays.sort(propertySources, psComp);
         for(int i=0;i<propertySources.length;i++){
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
     }
 
@@ -389,7 +389,7 @@ public class ConfigurationContextBuilderTest {
         b.sortPropertyFilter(pfComp);
         Arrays.sort(propertyFilters, pfComp);
         for(int i=0;i<propertyFilters.length;i++){
-            assertEquals(propertyFilters[i], b.getPropertyFilters().get(i));
+            assertThat(b.getPropertyFilters().get(i)).isEqualTo(propertyFilters[i]);
         }
     }
 
@@ -397,26 +397,26 @@ public class ConfigurationContextBuilderTest {
     public void build() throws Exception {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder();
         ConfigurationContext ctx = b.build();
-        assertNotNull(ctx);
-        assertTrue(ctx.getPropertySources().isEmpty());
-        assertTrue(ctx.getPropertyFilters().isEmpty());
+        assertThat(ctx).isNotNull();
+        assertThat(ctx.getPropertySources().isEmpty()).isTrue();
+        assertThat(ctx.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
     public void testRemoveAllFilters() throws Exception {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertyFilters((value, context) -> value.toBuilder().setValue(toString() + " - ").build());
-        assertFalse(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isFalse();
         b.removePropertyFilters(b.getPropertyFilters());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
     public void testRemoveAllSources() throws Exception {
         ConfigurationContextBuilder b = ConfigurationProvider.getConfigurationContextBuilder();
         b.addPropertySources(new TestPropertySource());
-        assertFalse(b.getPropertySources().isEmpty());
+        assertThat(b.getPropertySources().isEmpty()).isFalse();
         b.removePropertySources(b.getPropertySources());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/ConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/ConfigurationTest.java
@@ -22,9 +22,7 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This tests checks if the combination of 2 prioritized PropertySource return valid results of the final configuration.
@@ -33,7 +31,7 @@ public class ConfigurationTest {
 
     @Test
     public void testAccess(){
-        assertNotNull(current());
+        assertThat(current()).isNotNull();
     }
 
     private Configuration current() {
@@ -42,16 +40,16 @@ public class ConfigurationTest {
 
     @Test
     public void testContent(){
-        assertNotNull(current().get("name"));
-        assertNotNull(current().get("name2")); // from default
-        assertNotNull(current().get("name3")); // overridden default, mapped by filter to name property
-        assertNotNull(current().get("name4")); // final only
+        assertThat(current().get("name")).isNotNull();
+        assertThat(current().get("name2")).isNotNull(); // from default
+        assertThat(current().get("name3")).isNotNull(); // overridden default, mapped by filter to name property
+        assertThat(current().get("name4")).isNotNull(); // final only
 
 
-        assertEquals("Robin", current().get("name"));
-        assertEquals("Sabine", current().get("name2")); // from default
-        assertEquals("Mapped to name: Robin", current().get("name3"));  // overridden default, mapped by filter to name property
-        assertEquals("Sereina(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)", current().get("name4")); // final only
-        assertNull(current().get("name5")); // final only, but removed from filter
+        assertThat(current().get("name")).isEqualTo("Robin");
+        assertThat(current().get("name2")).isEqualTo("Sabine"); // from default
+        assertThat(current().get("name3")).isEqualTo("Mapped to name: Robin");  // overridden default, mapped by filter to name property
+        assertThat(current().get("name4")).isEqualTo("Sereina(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)(filtered)"); // final only
+        assertThat(current().get("name5")).isNull(); // final only, but removed from filter
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/OSGIActivatorTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/OSGIActivatorTest.java
@@ -25,9 +25,7 @@ import org.apache.tamaya.core.internal.MockBundleContext;
 import org.apache.tamaya.spi.ServiceContext;
 import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
@@ -69,13 +67,13 @@ public class OSGIActivatorTest {
 
         //Start
         instance.start(mockBundleContext);
-        assertEquals(1, mockBundleContext.getBundleListenersCount());
-        assertFalse(ConfigurationProvider.getConfiguration().getContext().getPropertyConverters().isEmpty());
-        assertNotSame(prevConfiguration, ConfigurationProvider.getConfiguration());
+        assertThat(mockBundleContext.getBundleListenersCount()).isEqualTo(1);
+        assertThat(ConfigurationProvider.getConfiguration().getContext().getPropertyConverters().isEmpty()).isFalse();
+        assertThat(ConfigurationProvider.getConfiguration()).isNotSameAs(prevConfiguration);
 
         //Stop
         instance.stop(mockBundleContext);
-        assertEquals(0, mockBundleContext.getBundleListenersCount());
+        assertThat(mockBundleContext.getBundleListenersCount()).isEqualTo(0);
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
@@ -36,7 +36,7 @@ import java.util.Currency;
 import java.util.Map;
 import org.apache.tamaya.core.internal.converters.BigDecimalConverter;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link CoreConfigurationBuilder} by atsticks on 06.09.16.
@@ -50,7 +50,7 @@ public class CoreConfigurationBuilderTest {
         ConfigurationContext context = ConfigurationProvider.getConfiguration().getContext();
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .setContext(context);
-        assertEquals(context, b.build().getContext());
+        assertThat(b.build().getContext()).isEqualTo(context);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class CoreConfigurationBuilderTest {
         Configuration cfg = ConfigurationProvider.getConfiguration();
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .setConfiguration(cfg);
-        assertEquals(cfg, b.build());
+        assertThat(b.build()).isEqualTo(cfg);
     }
 
     
@@ -69,9 +69,9 @@ public class CoreConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -81,17 +81,17 @@ public class CoreConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
         b = new CoreConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertySources().size());
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(1);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -102,13 +102,13 @@ public class CoreConfigurationBuilderTest {
         b.addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new CoreConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -119,17 +119,17 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new CoreConfigurationBuilder()
                 .addPropertyFilters(filter1, filter2);
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
     }
 
     @Test
@@ -140,12 +140,12 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = new CoreConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
     }
 
     @Test
@@ -156,15 +156,15 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = new CoreConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.removePropertyConverters(TypeLiteral.of(String.class), converter);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -174,12 +174,12 @@ public class CoreConfigurationBuilderTest {
                 .setPropertyValueCombinationPolicy(combPol);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(ctx.getPropertyValueCombinationPolicy(), combPol);
+        assertThat(combPol).isEqualTo(ctx.getPropertyValueCombinationPolicy());
     }
 
     @Test
     public void build() throws Exception {
-        assertNotNull(new CoreConfigurationBuilder().build());
+        assertThat(new CoreConfigurationBuilder().build()).isNotNull();
     }
 
     @Test
@@ -193,23 +193,23 @@ public class CoreConfigurationBuilderTest {
         CoreConfigurationBuilder b = new CoreConfigurationBuilder();
         b.addCorePropertyConverters();
         Map<TypeLiteral<?>, Collection<PropertyConverter<?>>> converters = b.getPropertyConverter();
-        assertTrue(converters.containsKey(TypeLiteral.<BigDecimal>of(BigDecimal.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<BigInteger>of(BigInteger.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Boolean>of(Boolean.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Byte>of(Byte.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Character>of(Character.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Class<?>>of(Class.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Currency>of(Currency.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Double>of(Double.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<File>of(File.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Float>of(Float.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Integer>of(Integer.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Long>of(Long.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Number>of(Number.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Path>of(Path.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<Short>of(Short.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<URI>of(URI.class)));
-        assertTrue(converters.containsKey(TypeLiteral.<URL>of(URL.class)));
+        assertThat(converters.containsKey(TypeLiteral.<BigDecimal>of(BigDecimal.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<BigInteger>of(BigInteger.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Boolean>of(Boolean.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Byte>of(Byte.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Character>of(Character.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Class<?>>of(Class.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Currency>of(Currency.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Double>of(Double.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<File>of(File.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Float>of(Float.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Integer>of(Integer.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Long>of(Long.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Number>of(Number.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Path>of(Path.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<Short>of(Short.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<URI>of(URI.class))).isTrue();
+        assertThat(converters.containsKey(TypeLiteral.<URL>of(URL.class))).isTrue();
     }
 
     private static class TestPropertySource implements PropertySource{

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.core.internal;
 import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsticks on 11.09.16.
@@ -35,32 +35,30 @@ public class CoreConfigurationProviderTest {
 
     @Test
     public void getConfiguration() throws Exception {
-        assertNotNull(new CoreConfigurationProvider().getConfiguration());
+        assertThat(new CoreConfigurationProvider().getConfiguration()).isNotNull();
     }
 
     @Test
     public void createConfiguration() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertNotNull(new CoreConfigurationProvider().createConfiguration(cfg.getContext()));
-        assertEquals(cfg,
-                new CoreConfigurationProvider().createConfiguration(cfg.getContext()));
+        assertThat(new CoreConfigurationProvider().createConfiguration(cfg.getContext())).isNotNull();
+        assertThat(cfg).isEqualTo(new CoreConfigurationProvider().createConfiguration(cfg.getContext()));
     }
 
     @Test
     public void getConfigurationContext() throws Exception {
-        assertNotNull(new CoreConfigurationProvider().getConfigurationContext());
-        assertEquals(new CoreConfigurationProvider().getConfigurationContext(),
-                new CoreConfigurationProvider().getConfiguration().getContext());
+        assertThat(new CoreConfigurationProvider().getConfigurationContext()).isNotNull();
+        assertThat(new CoreConfigurationProvider().getConfigurationContext()).isEqualTo(new CoreConfigurationProvider().getConfiguration().getContext());
     }
 
     @Test
     public void getConfigurationContextBuilder() throws Exception {
-        assertNotNull(new CoreConfigurationProvider().getConfigurationContextBuilder());
+        assertThat(new CoreConfigurationProvider().getConfigurationContextBuilder()).isNotNull();
     }
 
     @Test
     public void getConfigurationBuilder() throws Exception {
-        assertNotNull(new CoreConfigurationProvider().getConfigurationBuilder());
+        assertThat(new CoreConfigurationProvider().getConfigurationBuilder()).isNotNull();
     }
 
     @SuppressWarnings("deprecation")
@@ -80,13 +78,13 @@ public class CoreConfigurationProviderTest {
     @SuppressWarnings("deprecation")
 	@Test
     public void isConfigurationContextSettable() throws Exception {
-        assertTrue(new CoreConfigurationProvider().isConfigurationContextSettable());
+        assertThat(new CoreConfigurationProvider().isConfigurationContextSettable()).isTrue();
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void isConfigurationSettable() throws Exception {
-        assertTrue(new CoreConfigurationProvider().isConfigurationSettable());
+        assertThat(new CoreConfigurationProvider().isConfigurationSettable()).isTrue();
     }
 
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.core.testdata.TestPropertyDefaultSource;
 import org.apache.tamaya.spi.*;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Simple tests for {@link CoreConfiguration} by atsticks on 16.08.16.
@@ -36,9 +36,9 @@ public class CoreConfigurationTest {
     public void addPropertySources() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
         TestPropertyDefaultSource def = new TestPropertyDefaultSource();
-        assertFalse(cfg.getContext().getPropertySources().contains(def));
+        assertThat(cfg.getContext().getPropertySources().contains(def)).isFalse();
         cfg.getContext().addPropertySources(def);
-        assertTrue(cfg.getContext().getPropertySources().contains(def));
+        assertThat(cfg.getContext().getPropertySources().contains(def)).isTrue();
     }
 
     @Test
@@ -49,11 +49,11 @@ public class CoreConfigurationTest {
     @Test
     public void getPropertySources() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertNotNull(cfg.getContext().getPropertySources());
-        assertEquals(cfg.getContext().getPropertySources().size(), 0);
+        assertThat(cfg.getContext().getPropertySources()).isNotNull();
+        assertThat(0).isEqualTo(cfg.getContext().getPropertySources().size());
         cfg = new CoreConfigurationBuilder().addDefaultPropertySources().build();
-        assertNotNull(cfg.getContext().getPropertySources());
-        assertEquals(7, cfg.getContext().getPropertySources().size());
+        assertThat(cfg.getContext().getPropertySources()).isNotNull();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(7);
     }
 
     @Test
@@ -61,11 +61,11 @@ public class CoreConfigurationTest {
         TestPropertyDefaultSource ps = new TestPropertyDefaultSource();
         Configuration cfg = new CoreConfigurationBuilder()
                 .addPropertySources(ps).build();
-        assertNotNull(cfg.getContext().getPropertySources());
-        assertEquals(cfg.getContext().getPropertySources().size(), 1);
-        assertNotNull((cfg.getContext()).getPropertySource(ps.getName()));
-        assertEquals(ps.getName(), cfg.getContext().getPropertySource(ps.getName()).getName());
-        assertNull(cfg.getContext().getPropertySource("huhu"));
+        assertThat(cfg.getContext().getPropertySources()).isNotNull();
+        assertThat(1).isEqualTo(cfg.getContext().getPropertySources().size());
+        assertThat((cfg.getContext()).getPropertySource(ps.getName())).isNotNull();
+        assertThat(cfg.getContext().getPropertySource(ps.getName()).getName()).isEqualTo(ps.getName());
+        assertThat(cfg.getContext().getPropertySource("huhu")).isNull();
 
     }
 
@@ -76,10 +76,10 @@ public class CoreConfigurationTest {
                 .addPropertySources(ps).build();
         Configuration cfg2 = new CoreConfigurationBuilder()
                 .addPropertySources(ps).build();
-        assertEquals(cfg1.hashCode(), cfg2.hashCode());
+        assertThat(cfg2.hashCode()).isEqualTo(cfg1.hashCode());
         cfg2 = new CoreConfigurationBuilder()
                 .build();
-        assertNotEquals(cfg1.hashCode(), cfg2.hashCode());
+        assertThat(cfg1.hashCode()).isNotEqualTo(cfg2.hashCode());
 
     }
 
@@ -92,9 +92,9 @@ public class CoreConfigurationTest {
                 return "";
             }
         };
-        assertFalse(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter));
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isFalse();
         cfg.getContext().addPropertyConverter(TypeLiteral.of(String.class), testConverter);
-        assertTrue(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter));
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
     }
 
     @Test
@@ -107,9 +107,9 @@ public class CoreConfigurationTest {
             }
         };
         cfg.getContext().addPropertyConverter(TypeLiteral.of(String.class), testConverter);
-        assertNotNull(cfg.getContext().getPropertyConverters());
-        assertTrue(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(String.class)));
-        assertTrue(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(String.class)).contains(testConverter));
+        assertThat(cfg.getContext().getPropertyConverters()).isNotNull();
+        assertThat(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(String.class))).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
         testConverter = new PropertyConverter() {
             @Override
             public Object convert(String value, ConversionContext context) {
@@ -117,8 +117,8 @@ public class CoreConfigurationTest {
             }
         };
         cfg.getContext().addPropertyConverter(TypeLiteral.of(Integer.class), testConverter);
-        assertTrue(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(Integer.class)));
-        assertTrue(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(Integer.class)).contains(testConverter));
+        assertThat(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(Integer.class))).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(Integer.class)).contains(testConverter)).isTrue();
     }
 
     @Test
@@ -130,12 +130,12 @@ public class CoreConfigurationTest {
                 return "";
             }
         };
-        assertNotNull(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)));
-        assertEquals(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size(),0);
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull();
+        assertThat(0).isEqualTo(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size());
         cfg.getContext().addPropertyConverter(TypeLiteral.of(String.class), testConverter);
-        assertNotNull(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)));
-        assertEquals(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size(),1);
-        assertTrue(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter));
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull();
+        assertThat(1).isEqualTo(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
 
     }
 
@@ -149,29 +149,29 @@ public class CoreConfigurationTest {
                 return value;
             }
         };
-        assertNotNull(cfg.getContext().getPropertyFilters());
-        assertFalse(cfg.getContext().getPropertyFilters().contains(testFilter));
+        assertThat(cfg.getContext().getPropertyFilters()).isNotNull();
+        assertThat(cfg.getContext().getPropertyFilters().contains(testFilter)).isFalse();
         cfg = cfg.toBuilder().addPropertyFilters(testFilter).build();
-        assertTrue(cfg.getContext().getPropertyFilters().contains(testFilter));
+        assertThat(cfg.getContext().getPropertyFilters().contains(testFilter)).isTrue();
     }
 
     @Test
     public void getPropertyValueCombinationPolicy() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertNotNull(cfg.getContext().getPropertyValueCombinationPolicy());
-        assertEquals(cfg.getContext().getPropertyValueCombinationPolicy(),
-                PropertyValueCombinationPolicy.DEFAULT_OVERRIDING_POLICY);
+        assertThat(cfg.getContext().getPropertyValueCombinationPolicy()).isNotNull();
+        assertThat(cfg.getContext().getPropertyValueCombinationPolicy())
+                .isEqualTo(PropertyValueCombinationPolicy.DEFAULT_OVERRIDING_POLICY);
     }
 
     @Test
     public void toBuilder() throws Exception {
-        assertNotNull(new CoreConfigurationBuilder().build().toBuilder());
+        assertThat(new CoreConfigurationBuilder().build().toBuilder()).isNotNull();
     }
 
     @Test
     public void testRoundTrip() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertEquals(cfg.toBuilder().build(), cfg);
+        assertThat(cfg).isEqualTo(cfg.toBuilder().build());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
@@ -18,13 +18,10 @@
  */
 package org.apache.tamaya.core.internal;
 
-import org.apache.tamaya.spi.PropertySource;
-import org.apache.tamaya.spisupport.propertysource.JavaConfigurationPropertySource;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.apache.tamaya.ConfigurationProvider.getConfiguration;
+import static org.assertj.core.api.Assertions.*;
 
 public class DefaultJavaConfigurationTest {
 
@@ -37,14 +34,14 @@ public class DefaultJavaConfigurationTest {
             String key = "confkey" + i;
             String value = "javaconf-value" + i;
             // check if we had our key in configuration.current
-            MatcherAssert.assertThat(getConfiguration().getProperties().containsKey(key), Matchers.is(true));
-            MatcherAssert.assertThat(value, Matchers.equalTo(getConfiguration().get(key)));
+            assertThat(getConfiguration().getProperties().containsKey(key)).isTrue();
+            assertThat(value).isEqualTo(getConfiguration().get(key));
         }
 
-        MatcherAssert.assertThat(getConfiguration().getProperties().containsKey("aaeehh"), Matchers.is(true));
-        MatcherAssert.assertThat(getConfiguration().getProperties().get("aaeehh"), Matchers.equalTo(A_UMLAUT));
+        assertThat(getConfiguration().getProperties().containsKey("aaeehh")).isTrue();
+        assertThat(getConfiguration().getProperties().get("aaeehh")).isEqualTo(A_UMLAUT);
 
-        MatcherAssert.assertThat(getConfiguration().getProperties().containsKey(O_UMLAUT), Matchers.is(true));
-        MatcherAssert.assertThat(getConfiguration().getProperties().get(O_UMLAUT), Matchers.equalTo("o"));
+        assertThat(getConfiguration().getProperties().containsKey(O_UMLAUT)).isTrue();
+        assertThat(getConfiguration().getProperties().get(O_UMLAUT)).isEqualTo("o");
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceComparatorTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceComparatorTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.core.internal;
 
 import javax.annotation.Priority;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceReference;
 
@@ -39,14 +39,13 @@ public class OSGIServiceComparatorTest {
         ServiceReference nullPriority = new MockServiceReference();
         ServiceReference high = new MockHighPriorityServiceReference();
         OSGIServiceComparator instance = new OSGIServiceComparator();
-        
-        assertEquals(1, instance.compare(low, high));
-        assertEquals(-1, instance.compare(high, low));
-        assertEquals(0, instance.compare(low, low));
-        
-        assertEquals(1, instance.compare(nullPriority, high));
-        assertEquals(-1, instance.compare(high, nullPriority));
-        assertEquals(0, instance.compare(nullPriority, low));
+        assertThat(1).isEqualTo(instance.compare(low, high));
+        assertThat(-1).isEqualTo(instance.compare(high, low));
+        assertThat(0).isEqualTo(instance.compare(low, low));
+
+        assertThat(1).isEqualTo(instance.compare(nullPriority, high));
+        assertThat(-1).isEqualTo(instance.compare(high, nullPriority));
+        assertThat(0).isEqualTo(instance.compare(nullPriority, low));
     }
 
     /**
@@ -55,13 +54,13 @@ public class OSGIServiceComparatorTest {
     @Test
     public void testGetPriority_Object() {
         ServiceReference low = new MockLowPriorityServiceReference();
-        assertEquals(1, OSGIServiceComparator.getPriority(low));
+        assertThat(OSGIServiceComparator.getPriority(low)).isEqualTo(1);
         
         ServiceReference nullPriority = new MockServiceReference();
-        assertEquals(1, OSGIServiceComparator.getPriority(nullPriority));
+        assertThat(OSGIServiceComparator.getPriority(nullPriority)).isEqualTo(1);
         
         ServiceReference high = new MockHighPriorityServiceReference();
-        assertEquals(10, OSGIServiceComparator.getPriority(high));
+        assertThat(OSGIServiceComparator.getPriority(high)).isEqualTo(10);
     }
 
     /**
@@ -69,9 +68,9 @@ public class OSGIServiceComparatorTest {
      */
     @Test
     public void testGetPriority_Class() {
-        assertEquals(10, OSGIServiceComparator.getPriority(MockHighPriorityServiceReference.class));
-        assertEquals(1, OSGIServiceComparator.getPriority(MockLowPriorityServiceReference.class));
-        assertEquals(1, OSGIServiceComparator.getPriority(MockServiceReference.class));
+        assertThat(OSGIServiceComparator.getPriority(MockHighPriorityServiceReference.class)).isEqualTo(10);
+        assertThat(OSGIServiceComparator.getPriority(MockLowPriorityServiceReference.class)).isEqualTo(1);
+        assertThat(OSGIServiceComparator.getPriority(MockServiceReference.class)).isEqualTo(1);
     }
     
     private class MockServiceReference implements ServiceReference {

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
@@ -27,7 +27,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -44,7 +44,7 @@ public class OSGIServiceContextTest {
     @Test
     public void testIsInitialized() {
         OSGIServiceContext instance = new OSGIServiceContext(Mockito.mock(OSGIServiceLoader.class));
-        assertTrue(instance.isInitialized());
+        assertThat(instance.isInitialized()).isTrue();
     }
 
     /**
@@ -53,7 +53,7 @@ public class OSGIServiceContextTest {
     @Test
     public void testOrdinal() {
         OSGIServiceContext instance = new OSGIServiceContext(Mockito.mock(OSGIServiceLoader.class));
-        assertEquals(10, instance.ordinal());
+        assertThat(instance.ordinal()).isEqualTo(10);
     }
 
     /**
@@ -66,9 +66,9 @@ public class OSGIServiceContextTest {
         OSGIServiceContext instance = new OSGIServiceContext(loader);
 
         Integer value = instance.create(Integer.class);
-        assertNull(value);
+        assertThat(value).isNull();
         value = instance.getService(Integer.class);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     /**
@@ -81,8 +81,8 @@ public class OSGIServiceContextTest {
         OSGIServiceContext instance = new OSGIServiceContext(loader);
 
         List services = instance.getServices(Integer.class);
-        assertNotNull(services);
-        assertTrue(services.isEmpty());
+        assertThat(services).isNotNull();
+        assertThat(services.isEmpty()).isTrue();
     }
 
     /**
@@ -101,10 +101,10 @@ public class OSGIServiceContextTest {
         OSGIServiceContext instance = new OSGIServiceContext(loader);
 
         Enumeration<URL> resources = instance.getResources("dummy" , ClassLoader.getSystemClassLoader());
-        assertNotNull(resources);
+        assertThat(resources).isNotNull();
         URL resource = (URL)resources.nextElement();
-        assertTrue(resource.toString().contains("mockbundle.service"));
-        assertFalse(resources.hasMoreElements());
+        assertThat(resource.toString().contains("mockbundle.service")).isTrue();
+        assertThat(resources.hasMoreElements()).isFalse();
     }
 
     /**
@@ -122,8 +122,8 @@ public class OSGIServiceContextTest {
         OSGIServiceContext instance = new OSGIServiceContext(loader);
 
         URL resource = instance.getResource("mockbundle.service", ClassLoader.getSystemClassLoader());
-        assertNotNull(resource);
-        assertTrue(resource.toString().contains("mockbundle.service"));
+        assertThat(resource).isNotNull();
+        assertThat(resource.toString().contains("mockbundle.service")).isTrue();
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.core.internal;
 
 import java.util.Set;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
@@ -39,7 +39,7 @@ public class OSGIServiceLoaderTest {
         BundleContext mockBundleContext = new MockBundleContext();
         OSGIServiceLoader instance = new OSGIServiceLoader(mockBundleContext);
         BundleContext result = instance.getBundleContext();
-        assertEquals(mockBundleContext, result);
+        assertThat(result).isEqualTo(mockBundleContext);
     }
 
     /**
@@ -57,7 +57,7 @@ public class OSGIServiceLoaderTest {
         mockBundleContext.installBundle(startedBundle);
         OSGIServiceLoader instance = new OSGIServiceLoader(mockBundleContext);
         Set<Bundle> result = instance.getResourceBundles();
-        assertFalse(result.isEmpty());
+        assertThat(result.isEmpty()).isFalse();
     }
 
     /**
@@ -90,24 +90,24 @@ public class OSGIServiceLoaderTest {
         mockBundleContext.setServiceCount(0);
         OSGIServiceLoader instance = new OSGIServiceLoader(mockBundleContext);
         resultBundles = instance.getResourceBundles();
-        assertEquals(1, resultBundles.size());
-        assertEquals(2, mockBundleContext.getServiceCount());
+        assertThat(resultBundles).hasSize(1);
+        assertThat(mockBundleContext.getServiceCount()).isEqualTo(2);
 
         //After start
         mockBundleContext.setServiceCount(0);
         BundleEvent startedEvent = new BundleEvent(BundleEvent.STARTED, flipBundle);
         instance.bundleChanged(startedEvent);
         resultBundles = instance.getResourceBundles();
-        assertEquals(2, resultBundles.size());
-        assertEquals(2, mockBundleContext.getServiceCount());
+        assertThat(resultBundles).hasSize(2);
+        assertThat(mockBundleContext.getServiceCount()).isEqualTo(2);
 
         //After stop
         mockBundleContext.setServiceCount(0);
         BundleEvent stoppedEvent = new BundleEvent(BundleEvent.STOPPED, flipBundle);
         instance.bundleChanged(stoppedEvent);
         resultBundles = instance.getResourceBundles();
-        assertEquals(1, resultBundles.size());
-        assertEquals(0, mockBundleContext.getServiceCount());
+        assertThat(resultBundles).hasSize(1);
+        assertThat(mockBundleContext.getServiceCount()).isEqualTo(0);
     }
 
     

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
@@ -26,8 +26,6 @@ import org.junit.Test;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -47,7 +45,7 @@ public class BigDecimalConverterTest {
 		Configuration config = ConfigurationProvider.getConfiguration();
 		BigDecimal valueRead = config.get("tests.converter.bd.decimal", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal(101), valueRead);
+		assertThat(valueRead).isEqualTo(new BigDecimal(101));
 	}
 
 	/**
@@ -61,16 +59,16 @@ public class BigDecimalConverterTest {
 		Configuration config = ConfigurationProvider.getConfiguration();
 		BigDecimal valueRead = config.get("tests.converter.bd.hex.lowerX", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("47"), valueRead);
+		assertThat(valueRead).isEqualTo(new BigDecimal("47"));
 		valueRead = config.get("tests.converter.bd.hex.upperX", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("63"), valueRead);
+		assertThat(valueRead).isEqualTo(new BigDecimal("63"));
 		valueRead = config.get("tests.converter.bd.hex.negLowerX", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("-47"), valueRead);
+		assertThat(valueRead).isEqualTo(new BigDecimal("-47"));
 		valueRead = config.get("tests.converter.bd.hex.negUpperX", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("-63"), valueRead);
+		assertThat(valueRead).isEqualTo(new BigDecimal("-63"));
 	}
 
 	/**
@@ -83,7 +81,7 @@ public class BigDecimalConverterTest {
 	public void testConvert_NotPresent() throws Exception {
 		Configuration config = ConfigurationProvider.getConfiguration();
 		BigDecimal valueRead = config.get("tests.converter.bd.foo", BigDecimal.class);
-		assertNull(valueRead);
+		assertThat(valueRead).isNull();
 	}
 
 	/**
@@ -97,8 +95,8 @@ public class BigDecimalConverterTest {
 		Configuration config = ConfigurationProvider.getConfiguration();
 		BigDecimal valueRead = config.get("tests.converter.bd.big", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"),
-				valueRead);
+		assertThat(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"))
+                        .isEqualTo(valueRead);
 	}
 
 	/**
@@ -112,8 +110,9 @@ public class BigDecimalConverterTest {
 		Configuration config = ConfigurationProvider.getConfiguration();
 		BigDecimal valueRead = config.get("tests.converter.bd.bigFloat", BigDecimal.class);
 		assertThat(valueRead).isNotNull();
-		assertEquals(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372"
-				+ "63723628763821638923628193612983618293628763"), valueRead);
+		assertThat(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372"
+				+ "63723628763821638923628193612983618293628763"))
+                        .isEqualTo(valueRead);
 	}
 
 	@Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
@@ -24,9 +24,8 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.junit.Ignore;
 import static org.mockito.Mockito.mock;
 
@@ -47,7 +46,7 @@ public class BigIntegerConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         BigInteger valueRead = config.get("tests.converter.bd.decimal", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(BigInteger.valueOf(101), valueRead);
+        assertThat(valueRead).isEqualTo(BigInteger.valueOf(101));
     }
 
     /**
@@ -61,16 +60,16 @@ public class BigIntegerConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         BigInteger valueRead = config.get("tests.converter.bd.hex.lowerX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("47"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("47"));
         valueRead = config.get("tests.converter.bd.hex.upperX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("63"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("63"));
         valueRead = config.get("tests.converter.bd.hex.negLowerX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("-47"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("-47"));
         valueRead = config.get("tests.converter.bd.hex.negUpperX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("-63"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("-63"));
 
     }
 
@@ -86,10 +85,10 @@ public class BigIntegerConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         BigInteger valueRead = config.get("tests.converter.bd.hex.subTenX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("16777215"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("16777215"));
         valueRead = config.get("tests.converter.bd.hex.negSubTenX", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("-263"), valueRead);
+        assertThat(valueRead).isEqualTo(new BigInteger("-263"));
     }
 
     @Test(expected = ConfigException.class)
@@ -114,7 +113,7 @@ public class BigIntegerConverterTest {
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         BigInteger valueRead = config.get("tests.converter.bd.foo", BigInteger.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     /**
@@ -128,8 +127,8 @@ public class BigIntegerConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         BigInteger valueRead = config.get("tests.converter.bd.big", BigInteger.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(new BigInteger("101666666666666662333337263723628763821638923628193612983618293628763"),
-                valueRead);
+        assertThat(new BigInteger("101666666666666662333337263723628763821638923628193612983618293628763"))
+                .isEqualTo(valueRead);
     }
 
     @Test
@@ -149,13 +148,13 @@ public class BigIntegerConverterTest {
         BigInteger value = converter.convert("", context);
 
         assertThat(value).isNull();
-        assertTrue(context.getSupportedFormats().contains("<bigint> -> new BigInteger(bigint) (BigIntegerConverter)"));
+        assertThat(context.getSupportedFormats().contains("<bigint> -> new BigInteger(bigint) (BigIntegerConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         BigIntegerConverter instance = new BigIntegerConverter();
-        assertEquals(BigIntegerConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(BigIntegerConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
@@ -19,16 +19,12 @@
 package org.apache.tamaya.core.internal.converters;
 
 import org.apache.tamaya.ConfigException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -46,35 +42,35 @@ public class BooleanConverterTest {
     public void testConvert_BooleanTrue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Boolean valueRead = config.get("tests.converter.boolean.y1", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.y2", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.yes1", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.yes2", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.yes3", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.true1", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.true2", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.true3", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.t1", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.boolean.t2", Boolean.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Boolean.TRUE);
+        assertThat(valueRead).isNotNull();
+        assertThat(Boolean.TRUE).isEqualTo(valueRead);
     }
 
     /**
@@ -87,39 +83,39 @@ public class BooleanConverterTest {
     public void testConvert_BooleanFalse() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Boolean valueRead = config.get("tests.converter.boolean.y1", Boolean.class);
-        assertNotNull(valueRead);
+        assertThat(valueRead).isNotNull();
         valueRead = config.get("tests.converter.boolean.n1", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.n2", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.no1", Boolean.class);
-        assertFalse(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isFalse();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.no2", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.no3", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.false1", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.false2", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.false3", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.f1", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.f2", Boolean.class);
-        assertNotNull(valueRead);
-        assertFalse(valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isFalse();
         valueRead = config.get("tests.converter.boolean.foo", Boolean.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     /**
@@ -132,7 +128,7 @@ public class BooleanConverterTest {
     public void testConvert_BooleanInvalid() throws ConfigException {
         Configuration config = ConfigurationProvider.getConfiguration();
         Boolean valueRead = config.get("tests.converter.boolean.invalid", Boolean.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     @Test
@@ -141,14 +137,14 @@ public class BooleanConverterTest {
         BooleanConverter converter = new BooleanConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("true (ignore case) (BooleanConverter)"));
-        assertTrue(context.getSupportedFormats().contains("false (ignore case) (BooleanConverter)"));
+        assertThat(context.getSupportedFormats().contains("true (ignore case) (BooleanConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("false (ignore case) (BooleanConverter)")).isTrue();
     }
     
     @Test
     public void testHashCode() {
         BooleanConverter instance = new BooleanConverter();
-        assertEquals(BooleanConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(BooleanConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 /**
  * Tests the default converter for bytes.
@@ -41,19 +41,19 @@ public class ByteConverterTest {
     public void testConvert_Byte() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Byte valueRead = config.get("tests.converter.byte.decimal", Byte.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead.byteValue(), 101);
+        assertThat(valueRead).isNotNull();
+        assertThat(101).isEqualTo(valueRead.byteValue());
         valueRead = config.get("tests.converter.byte.octal", Byte.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead.byteValue(), Byte.decode("02").byteValue());
+        assertThat(valueRead).isNotNull();
+        assertThat(Byte.decode("02").byteValue()).isEqualTo(valueRead.byteValue());
         valueRead = config.get("tests.converter.byte.hex.lowerX", Byte.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead.byteValue(), Byte.decode("0x2F").byteValue());
+        assertThat(valueRead).isNotNull();
+        assertThat(Byte.decode("0x2F").byteValue()).isEqualTo(valueRead.byteValue());
         valueRead = config.get("tests.converter.byte.hex.upperX", Byte.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead.byteValue(), Byte.decode("0X3F").byteValue());
+        assertThat(valueRead).isNotNull();
+        assertThat(Byte.decode("0X3F").byteValue()).isEqualTo(valueRead.byteValue());
         valueRead = config.get("tests.converter.byte.foo", Byte.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     /**
@@ -66,7 +66,7 @@ public class ByteConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Byte valueRead = config.get("tests.converter.byte.min", Byte.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Byte.MIN_VALUE, valueRead.byteValue());
+        assertThat(valueRead.byteValue()).isEqualTo(Byte.MIN_VALUE);
     }
 
     /**
@@ -79,7 +79,7 @@ public class ByteConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Byte valueRead = config.get("tests.converter.byte.max", Byte.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Byte.MAX_VALUE, valueRead.byteValue());
+        assertThat(valueRead.byteValue()).isEqualTo(Byte.MAX_VALUE);
     }
     /**
      * Test conversion. The value are provided by
@@ -91,7 +91,7 @@ public class ByteConverterTest {
     public void testConvert_ByteInvalid() throws ConfigException {
         Configuration config = ConfigurationProvider.getConfiguration();
         Byte valueRead = config.get("tests.converter.byte.invalid", Byte.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     @Test
@@ -100,14 +100,14 @@ public class ByteConverterTest {
         ByteConverter converter = new ByteConverter();
         converter.convert("", context);
         
-        assertTrue(context.getSupportedFormats().contains("<byte> (ByteConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (ByteConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (ByteConverter)"));
+        assertThat(context.getSupportedFormats().contains("<byte> (ByteConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (ByteConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (ByteConverter)")).isTrue();
     }
     
     @Test
     public void testHashCode() {
         ByteConverter instance = new ByteConverter();
-        assertEquals(ByteConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(ByteConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -38,7 +38,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'f');
+        assertThat('f').isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f-numeric", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), (char) 101);
+        assertThat((char) 101).isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.d", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'd');
+        assertThat('d').isEqualTo(valueRead.charValue());
 
     }
 
@@ -63,7 +63,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.single-quote", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), '\'');
+        assertThat('\'').isEqualTo(valueRead.charValue());
     }
 
     @Test(expected = ConfigException.class)
@@ -77,7 +77,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.three-single-quotes", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), '\'');
+        assertThat('\'').isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f-before", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'f');
+        assertThat('f').isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f-after", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'f');
+        assertThat('f').isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -101,14 +101,14 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.f-around", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'f');
+        assertThat('f').isEqualTo(valueRead.charValue());
     }
 
     @Test
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.foo", Character.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     /**
@@ -122,7 +122,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.invalid", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'i'); //Strings return the first character
+        assertThat('i').isEqualTo(valueRead.charValue()); //Strings return the first character
     }
 
     @Test
@@ -130,7 +130,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.quoted-invalid", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'i'); //Strings return the first character
+        assertThat('i').isEqualTo(valueRead.charValue()); //Strings return the first character
     }
 
     @Test
@@ -138,7 +138,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.あ", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'あ');
+        assertThat('あ').isEqualTo(valueRead.charValue());
     }
 
     @Test
@@ -146,7 +146,7 @@ public class CharConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Character valueRead = config.get("tests.converter.char.กขฃคฅฆงจฉช", Character.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead.charValue(), 'ก'); //Strings return the first character
+        assertThat('ก').isEqualTo(valueRead.charValue()); //Strings return the first character
     }
 
     @Test
@@ -155,13 +155,13 @@ public class CharConverterTest {
         CharConverter converter = new CharConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<char> (CharConverter)"));
-        assertTrue(context.getSupportedFormats().contains("\\'<char>\\' (CharConverter)"));
+        assertThat(context.getSupportedFormats().contains("<char> (CharConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("\\'<char>\\' (CharConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         CharConverter instance = new CharConverter();
-        assertEquals(CharConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(CharConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests conversion of the {@link ClassConverter}.
@@ -37,32 +37,32 @@ public class ClassConverterTest {
     @Test
     public void testConvert_Class() throws Exception {
         ClassConverter converter = new ClassConverter();
-        assertEquals(BigDecimal.class, converter.convert("java.math.BigDecimal", context));
+        assertThat(BigDecimal.class).isEqualTo(converter.convert("java.math.BigDecimal", context));
     }
 
     @Test
     public void testConvert_Class_WithSpaces() throws Exception {
         ClassConverter converter = new ClassConverter();
-        assertEquals(BigDecimal.class, converter.convert("  java.math.BigDecimal\t", context));
+         assertThat(BigDecimal.class).isEqualTo(converter.convert("  java.math.BigDecimal\t", context));
     }
 
     @Test
     public void testConvert_Class_WithSpacesBefore() throws Exception {
         ClassConverter converter = new ClassConverter();
-        assertEquals(BigDecimal.class, converter.convert("  java.math.BigDecimal", context));
+        assertThat(BigDecimal.class).isEqualTo(converter.convert("  java.math.BigDecimal", context));
     }
 
     @Test
     public void testConvert_Class_WithSpacesAfter() throws Exception {
         ClassConverter converter = new ClassConverter();
-        assertEquals(BigDecimal.class, converter.convert("java.math.BigDecimal  ", context));
+        assertThat(BigDecimal.class).isEqualTo(converter.convert("java.math.BigDecimal  ", context));
     }
 
     @Test
     public void testConvert_NotPresent() throws Exception {
         ClassConverter converter = new ClassConverter();
-        assertNull(converter.convert("", context));
-        assertNull(converter.convert(null, context));
+        assertThat(converter.convert("", context)).isNull();
+        assertThat(converter.convert(null, context)).isNull();
     }
 
     @Test
@@ -71,12 +71,12 @@ public class ClassConverterTest {
         ClassConverter converter = new ClassConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().contains("<fullyQualifiedClassName> (ClassConverter)"));
+        assertThat(localcontext.getSupportedFormats().contains("<fullyQualifiedClassName> (ClassConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         ClassConverter instance = new ClassConverter();
-        assertEquals(ClassConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(ClassConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConvertQueryTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConvertQueryTest.java
@@ -22,7 +22,7 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -38,7 +38,7 @@ public class ConvertQueryTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         ConvertQuery<Integer> converter = new ConvertQuery<>("101", TypeLiteral.of(Integer.class));
         Integer result = converter.query(config);
-        assertEquals(101, result.longValue());
+        assertThat(result.longValue()).isEqualTo(101);
     }
 
     /**
@@ -49,7 +49,7 @@ public class ConvertQueryTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         ConvertQuery<Integer> converter = new ConvertQuery<>("101", TypeLiteral.of(Integer.class));
         Integer result = config.query(converter);
-        assertEquals(101, result.longValue());
+        assertThat(result.longValue()).isEqualTo(101);
     }
 
     /**
@@ -60,10 +60,10 @@ public class ConvertQueryTest {
         Configuration config = ConfigurationProvider.getConfiguration();
 
         Integer intResult = (Integer) new ConvertQuery("101", TypeLiteral.of(Integer.class)).query(config);
-        assertEquals(101, intResult.longValue());
+        assertThat(intResult.longValue()).isEqualTo(101);
 
         Boolean booleanResult = (Boolean) new ConvertQuery("true", TypeLiteral.of(Boolean.class)).query(config);
-        assertEquals(Boolean.TRUE, booleanResult);
+        assertThat(booleanResult).isEqualTo(Boolean.TRUE);
     }
 
     /**
@@ -74,7 +74,7 @@ public class ConvertQueryTest {
         Configuration config = ConfigurationProvider.getConfiguration();
 
         Integer intResult = (Integer) new ConvertQuery("invalid", TypeLiteral.of(Integer.class)).query(config);
-        assertNull(intResult);
+        assertThat(intResult).isNull();
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
@@ -28,7 +28,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the default converter for currencies.
@@ -51,7 +51,7 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code1", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead, Currency.getInstance(CHF));
+        assertThat(Currency.getInstance(CHF)).isEqualTo(valueRead);
     }
 
     /**
@@ -65,7 +65,7 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code2", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(valueRead, Currency.getInstance(CHF));
+        assertThat(Currency.getInstance(CHF)).isEqualTo(valueRead);
     }
 
     /**
@@ -79,7 +79,7 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code3", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(CHF), valueRead);
+        assertThat(valueRead).isEqualTo(Currency.getInstance(CHF));
     }
 
     /**
@@ -93,7 +93,7 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code4", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(CHF), valueRead);
+        assertThat(valueRead).isEqualTo(Currency.getInstance(CHF));
     }
 
     /**
@@ -107,7 +107,7 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code5", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(CHF), valueRead);
+        assertThat(valueRead).isEqualTo(Currency.getInstance(CHF));
     }
 
     /**
@@ -121,16 +121,16 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code-numeric1", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(BGL).getNumericCode(), valueRead.getNumericCode());
+        assertThat(valueRead.getNumericCode()).isEqualTo(Currency.getInstance(BGL).getNumericCode());
         valueRead = config.get("tests.converter.currency.code-numeric2", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(BGL).getNumericCode(), valueRead.getNumericCode());
+        assertThat(valueRead.getNumericCode()).isEqualTo(Currency.getInstance(BGL).getNumericCode());
         valueRead = config.get("tests.converter.currency.code-numeric3", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(BGL).getNumericCode(), valueRead.getNumericCode());
+        assertThat(valueRead.getNumericCode()).isEqualTo(Currency.getInstance(BGL).getNumericCode());
         valueRead = config.get("tests.converter.currency.code-numeric4", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(Currency.getInstance(BGL).getNumericCode(), valueRead.getNumericCode());
+        assertThat(valueRead.getNumericCode()).isEqualTo(Currency.getInstance(BGL).getNumericCode());
     }
 
     /**
@@ -144,16 +144,16 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code-locale1", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(EUR, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(EUR);
         valueRead = config.get("tests.converter.currency.code-locale2", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(EUR, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(EUR);
         valueRead = config.get("tests.converter.currency.code-locale3", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(EUR, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(EUR);
         valueRead = config.get("tests.converter.currency.code-locale4", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(EUR, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(EUR);
     }
 
     /**
@@ -167,17 +167,17 @@ public class CurrencyConverterTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code-locale-twopart", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(JPY, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(JPY);
         valueRead = config.get("tests.converter.currency.code-locale-threepart", Currency.class);
         assertThat(valueRead).isNotNull();
-        assertEquals(JPY, valueRead.getCurrencyCode());
+        assertThat(valueRead.getCurrencyCode()).isEqualTo(JPY);
     }
 
     @Test(expected = ConfigException.class)
     public void testConvert_Currency_Code_Fourpart_Locale_Invalid() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Currency valueRead = config.get("tests.converter.currency.code-locale-fourpart", Currency.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     @Test(expected = ConfigException.class)
@@ -192,14 +192,14 @@ public class CurrencyConverterTest {
         CurrencyConverter converter = new CurrencyConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<numericValue> (CurrencyConverter)"));
-        assertTrue(context.getSupportedFormats().contains("<locale> (CurrencyConverter)"));
-        assertTrue(context.getSupportedFormats().contains("<currencyCode>, using Locale.ENGLISH (CurrencyConverter)"));
+        assertThat(context.getSupportedFormats().contains("<numericValue> (CurrencyConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("<locale> (CurrencyConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("<currencyCode>, using Locale.ENGLISH (CurrencyConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         CurrencyConverter instance = new CurrencyConverter();
-        assertEquals(CurrencyConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(CurrencyConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
@@ -23,10 +23,9 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the default converter for doubles.
@@ -42,8 +41,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.decimal", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead, 1.23456789, 0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(1.23456789).isCloseTo(valueRead, within(0.0d));
     }
 
     /**
@@ -55,8 +54,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_DecimalNegative() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.decimalNegative", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead, -1.23456789, 0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(-1.23456789).isCloseTo(valueRead, within(0.0d));
     }
 
     /**
@@ -68,8 +67,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_Integer() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.integer", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,100d, 0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(100d).isCloseTo(valueRead, within(0.0d));
     }
 
     /**
@@ -81,8 +80,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_Hex1() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.hex1", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,255d, 0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(255d).isCloseTo(valueRead, within(0.0d));
     }
 
     /**
@@ -94,8 +93,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_Hex2() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.hex2", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,-255d, 0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(-255d).isCloseTo(valueRead, within(0.0d));
     }
 
     /**
@@ -107,7 +106,7 @@ public class DoubleConverterTest {
     public void testConvert_Double_Hex3() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.hex3", Double.class);
-        assertTrue(valueRead!=null);
+        assertThat(valueRead!=null).isTrue();
     }
 
     /**
@@ -119,8 +118,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_MinValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.min", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Double.MIN_VALUE, valueRead,0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Double.MIN_VALUE, within(0.0d));
     }
 
     /**
@@ -132,8 +131,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_MaxValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.max", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Double.MAX_VALUE, valueRead,0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Double.MAX_VALUE, within(0.0d));
     }
 
     /**
@@ -145,8 +144,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_NaNValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.nan", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Double.NaN, valueRead,0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Double.NaN, within(0.0d));
     }
 
     /**
@@ -158,8 +157,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_PositiveInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.pi", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Double.POSITIVE_INFINITY, valueRead,0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Double.POSITIVE_INFINITY, within(0.0d));
     }
 
     /**
@@ -171,8 +170,8 @@ public class DoubleConverterTest {
     public void testConvert_Double_NegativeInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Double valueRead = config.get("tests.converter.double.ni", Double.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Double.NEGATIVE_INFINITY, valueRead,0.0d);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Double.NEGATIVE_INFINITY, within(0.0d));
     }
     
     
@@ -188,15 +187,15 @@ public class DoubleConverterTest {
         DoubleConverter converter = new DoubleConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<double> (DoubleConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (DoubleConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (DoubleConverter)"));
+        assertThat(context.getSupportedFormats().contains("<double> (DoubleConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (DoubleConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (DoubleConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         DoubleConverter instance = new DoubleConverter();
-        assertEquals(DoubleConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(DoubleConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.Duration;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -56,25 +56,25 @@ public class DurationConverterTest {
     public void convert() throws Exception {
         DurationConverter conv = new DurationConverter();
         Duration duration = conv.convert("PT20.345S", context);
-        assertEquals(Duration.parse("PT20.345S"), duration);
+        assertThat(duration).isEqualTo(Duration.parse("PT20.345S"));
         duration = conv.convert("PT15M", context);
-        assertEquals(Duration.parse("PT15M"), duration);
+        assertThat(duration).isEqualTo(Duration.parse("PT15M"));
         duration = conv.convert("PT10H", context);
-        assertEquals(Duration.parse("PT10H"), duration);
+        assertThat(duration).isEqualTo(Duration.parse("PT10H"));
         duration = conv.convert("P2D", context);
-        assertEquals(Duration.parse("P2D"), duration);
+        assertThat(duration).isEqualTo(Duration.parse("P2D"));
         duration = conv.convert("P2DT3H4M", context);
-        assertEquals(Duration.parse("P2DT3H4M"), duration);
+        assertThat(duration).isEqualTo(Duration.parse("P2DT3H4M"));
         duration = conv.convert("foo", context);
-        assertNull(duration);
+        assertThat(duration).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         DurationConverter conv1 = new DurationConverter();
         DurationConverter conv2 = new DurationConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -83,13 +83,13 @@ public class DurationConverterTest {
         DurationConverter converter = new DurationConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().contains("PT20M34S (DurationConverter)"));
+        assertThat(localcontext.getSupportedFormats().contains("PT20M34S (DurationConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         DurationConverter instance = new DurationConverter();
-        assertEquals(DurationConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(DurationConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
@@ -23,7 +23,7 @@ import java.net.URL;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -41,18 +41,18 @@ public class FileConverterTest {
         FileConverter instance = new FileConverter();
         File result;
         
-        assertNull(instance.convert(null, context));
+        assertThat(instance.convert(null, context)).isNull();
         
         URL testfileUrl = getClass().getResource("/testfile.properties");
         System.out.println(testfileUrl.toString());
         result = instance.convert(testfileUrl.toString(), context);
-        assertNotNull(result);
-        assertTrue(context.getSupportedFormats().contains("<File> (FileConverter)"));
+        assertThat(result).isNotNull();
+        assertThat(context.getSupportedFormats().contains("<File> (FileConverter)")).isTrue();
     }
     
     @Test
     public void testHashCode(){
         FileConverter instance = new FileConverter();
-        assertEquals(FileConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(FileConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
@@ -23,10 +23,9 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the default converter for bytes.
@@ -42,8 +41,8 @@ public class FloatConverterTest {
     public void testConvert_Float_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.decimal", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead, 1.23456789f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(1.23456789f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -55,8 +54,8 @@ public class FloatConverterTest {
     public void testConvert_Float_DecimalNegative() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.decimalNegative", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead, -1.23456789f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(-1.23456789f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -68,8 +67,8 @@ public class FloatConverterTest {
     public void testConvert_Float_Integer() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.integer", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,100f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(100f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -81,8 +80,8 @@ public class FloatConverterTest {
     public void testConvert_Float_Hex1() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.hex1", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,255f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(255f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -94,8 +93,8 @@ public class FloatConverterTest {
     public void testConvert_Float_Hex2() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.hex2", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,-255f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(-255f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -107,8 +106,8 @@ public class FloatConverterTest {
     public void testConvert_Float_Hex3() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.hex3", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(valueRead,255f, 0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(255f).isCloseTo(valueRead, within(0.0f));
     }
 
     /**
@@ -120,8 +119,8 @@ public class FloatConverterTest {
     public void testConvert_Float_MinValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.min", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Float.MIN_VALUE, valueRead,0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Float.MIN_VALUE, within(0.0f));
     }
 
     /**
@@ -133,8 +132,8 @@ public class FloatConverterTest {
     public void testConvert_Float_MaxValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.max", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Float.MAX_VALUE, valueRead,0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Float.MAX_VALUE, within(0.0f));
     }
 
     /**
@@ -146,8 +145,8 @@ public class FloatConverterTest {
     public void testConvert_Float_NaNValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.nan", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Float.NaN, valueRead,0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Float.NaN, within(0.0f));
     }
 
     /**
@@ -159,8 +158,8 @@ public class FloatConverterTest {
     public void testConvert_Float_PositiveInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.pi", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Float.POSITIVE_INFINITY, valueRead,0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Float.POSITIVE_INFINITY, within(0.0f));
     }
 
     /**
@@ -172,8 +171,8 @@ public class FloatConverterTest {
     public void testConvert_Float_NegativeInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Float valueRead = config.get("tests.converter.float.ni", Float.class);
-        assertTrue(valueRead!=null);
-        assertEquals(Float.NEGATIVE_INFINITY, valueRead,0.0f);
+        assertThat(valueRead!=null).isTrue();
+        assertThat(valueRead).isCloseTo(Float.NEGATIVE_INFINITY, within(0.0f));
     }
       
     @Test(expected = ConfigException.class)
@@ -188,15 +187,15 @@ public class FloatConverterTest {
         FloatConverter converter = new FloatConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<float> (FloatConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (FloatConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (FloatConverter)"));
+        assertThat(context.getSupportedFormats().contains("<float> (FloatConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (FloatConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (FloatConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         FloatConverter instance = new FloatConverter();
-        assertEquals(FloatConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(FloatConverter.class.hashCode());
     }
 
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.Instant;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -42,17 +42,17 @@ public class InstantConverterTest {
     public void convert() throws Exception {
         InstantConverter conv = new InstantConverter();
         Instant value = conv.convert("2007-12-03T10:15:30.00Z", context);
-        assertEquals(value, Instant.parse("2007-12-03T10:15:30.00Z"));
+        assertThat(Instant.parse("2007-12-03T10:15:30.00Z")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         InstantConverter conv1 = new InstantConverter();
         InstantConverter conv2 = new InstantConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -61,13 +61,13 @@ public class InstantConverterTest {
         InstantConverter converter = new InstantConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (InstantConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (InstantConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         InstantConverter instance = new InstantConverter();
-        assertEquals(InstantConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(InstantConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the default converter for Integers.
@@ -41,8 +41,8 @@ public class IntegerConverterTest {
     public void testConvert_Integer_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.decimal", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), 101);
+        assertThat(valueRead != null).isTrue();
+        assertThat(101).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -54,8 +54,8 @@ public class IntegerConverterTest {
     public void testConvert_Integer_Octal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.octal", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Integer.decode("02").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Integer.decode("02").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -67,11 +67,11 @@ public class IntegerConverterTest {
     public void testConvert_Integer_Hex() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.hex.lowerX", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Integer.decode("0x2F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Integer.decode("0x2F").intValue()).isEqualTo(valueRead.intValue());
         valueRead = config.get("tests.converter.integer.hex.upperX", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Integer.decode("0X3F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Integer.decode("0X3F").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -83,7 +83,7 @@ public class IntegerConverterTest {
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.foo", Integer.class);
-        assertFalse(valueRead != null);
+        assertThat(valueRead != null).isFalse();
     }
 
     /**
@@ -95,8 +95,8 @@ public class IntegerConverterTest {
     public void testConvert_Integer_MinValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.min", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(Integer.MIN_VALUE, valueRead.intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.intValue()).isEqualTo(Integer.MIN_VALUE);
     }
 
     /**
@@ -108,8 +108,8 @@ public class IntegerConverterTest {
     public void testConvert_Integer_MaxValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Integer valueRead = config.get("tests.converter.integer.max", Integer.class);
-        assertTrue(valueRead != null);
-        assertEquals(Integer.MAX_VALUE, valueRead.intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.intValue()).isEqualTo(Integer.MAX_VALUE);
     }
         
     @Test(expected = ConfigException.class)
@@ -124,14 +124,14 @@ public class IntegerConverterTest {
         IntegerConverter converter = new IntegerConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<int> (IntegerConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (IntegerConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (IntegerConverter)"));
+        assertThat(context.getSupportedFormats().contains("<int> (IntegerConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (IntegerConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (IntegerConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         IntegerConverter instance = new IntegerConverter();
-        assertEquals(IntegerConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(IntegerConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.LocalDate;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -42,17 +42,17 @@ public class LocalDateConverterTest {
     public void convert() throws Exception {
         LocalDateConverter conv = new LocalDateConverter();
         LocalDate value = conv.convert("2007-12-03", context);
-        assertEquals(value, LocalDate.parse("2007-12-03"));
+        assertThat(LocalDate.parse("2007-12-03")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         LocalDateConverter conv1 = new LocalDateConverter();
         LocalDateConverter conv2 = new LocalDateConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -61,12 +61,12 @@ public class LocalDateConverterTest {
         LocalDateConverter converter = new LocalDateConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (LocalDateConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (LocalDateConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         LocalDateConverter instance = new LocalDateConverter();
-        assertEquals(LocalDateConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(LocalDateConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.LocalDateTime;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -42,17 +42,17 @@ public class LocalDateTimeConverterTest {
     public void convert() throws Exception {
         LocalDateTimeConverter conv = new LocalDateTimeConverter();
         LocalDateTime value = conv.convert("2007-12-03T10:15:30", context);
-        assertEquals(value, LocalDateTime.parse("2007-12-03T10:15:30"));
+        assertThat(LocalDateTime.parse("2007-12-03T10:15:30")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         LocalDateTimeConverter conv1 = new LocalDateTimeConverter();
         LocalDateTimeConverter conv2 = new LocalDateTimeConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -61,12 +61,12 @@ public class LocalDateTimeConverterTest {
         LocalDateTimeConverter converter = new LocalDateTimeConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (LocalDateTimeConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (LocalDateTimeConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         LocalDateTimeConverter instance = new LocalDateTimeConverter();
-        assertEquals(LocalDateTimeConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(LocalDateTimeConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.LocalTime;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -42,17 +42,17 @@ public class LocalTimeConverterTest {
     public void convert() throws Exception {
         LocalTimeConverter conv = new LocalTimeConverter();
         LocalTime value = conv.convert("10:15:30", context);
-        assertEquals(value, LocalTime.parse("10:15:30"));
+        assertThat(LocalTime.parse("10:15:30")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         LocalTimeConverter conv1 = new LocalTimeConverter();
         LocalTimeConverter conv2 = new LocalTimeConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -61,12 +61,12 @@ public class LocalTimeConverterTest {
         LocalTimeConverter converter = new LocalTimeConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (LocalTimeConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (LocalTimeConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         LocalTimeConverter instance = new LocalTimeConverter();
-        assertEquals(LocalTimeConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(LocalTimeConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the default converter for Longs.
@@ -41,8 +41,8 @@ public class LongConverterTest {
     public void testConvert_Long_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.decimal", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), 101);
+        assertThat(valueRead != null).isTrue();
+        assertThat(101).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -54,8 +54,8 @@ public class LongConverterTest {
     public void testConvert_Long_Octal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.octal", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Long.decode("02").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Long.decode("02").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -67,11 +67,11 @@ public class LongConverterTest {
     public void testConvert_Long_Hex() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.hex.lowerX", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Long.decode("0x2F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Long.decode("0x2F").intValue()).isEqualTo(valueRead.intValue());
         valueRead = config.get("tests.converter.long.hex.upperX", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Long.decode("0X3F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Long.decode("0X3F").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -83,7 +83,7 @@ public class LongConverterTest {
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.foo", Long.class);
-        assertFalse(valueRead != null);
+        assertThat(valueRead != null).isFalse();
     }
 
     /**
@@ -95,8 +95,8 @@ public class LongConverterTest {
     public void testConvert_Long_MinValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.min", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(Long.MIN_VALUE, valueRead.longValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.longValue()).isEqualTo(Long.MIN_VALUE);
     }
 
     /**
@@ -108,8 +108,8 @@ public class LongConverterTest {
     public void testConvert_Long_MaxValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Long valueRead = config.get("tests.converter.long.max", Long.class);
-        assertTrue(valueRead != null);
-        assertEquals(Long.MAX_VALUE, valueRead.longValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.longValue()).isEqualTo(Long.MAX_VALUE);
     }    
     
     @Test(expected = ConfigException.class)
@@ -124,14 +124,14 @@ public class LongConverterTest {
         LongConverter converter = new LongConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<long> (LongConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (LongConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (LongConverter)"));
+        assertThat(context.getSupportedFormats().contains("<long> (LongConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (LongConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (LongConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         LongConverter instance = new LongConverter();
-        assertEquals(LongConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(LongConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
@@ -27,7 +27,7 @@ import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the default converter for Number.
@@ -43,8 +43,8 @@ public class NumberConverterTest {
     public void testConvert_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.bd.decimal", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, 101L);
+        assertThat(valueRead).isNotNull();
+        assertThat(101L).isEqualTo(valueRead);
     }
 
 
@@ -57,11 +57,11 @@ public class NumberConverterTest {
     public void testConvert_Hex() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.bd.hex.lowerX", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Long.valueOf("47"));
+        assertThat(valueRead).isNotNull();
+        assertThat(Long.valueOf("47")).isEqualTo(valueRead);
         valueRead = config.get("tests.converter.bd.hex.upperX", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(valueRead, Long.valueOf("63"));
+        assertThat(valueRead).isNotNull();
+        assertThat(Long.valueOf("63")).isEqualTo(valueRead);
     }
 
     /**
@@ -73,7 +73,7 @@ public class NumberConverterTest {
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.bd.foo", Number.class);
-        assertNull(valueRead);
+        assertThat(valueRead).isNull();
     }
 
     /**
@@ -85,9 +85,9 @@ public class NumberConverterTest {
     public void testConvert_BigValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.bd.big", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"),
-                valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"))
+                .isEqualTo(valueRead);
     }
 
     /**
@@ -99,9 +99,10 @@ public class NumberConverterTest {
     public void testConvert_BigFloatValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.bd.bigFloat", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372" +
-                "63723628763821638923628193612983618293628763"), valueRead);
+        assertThat(valueRead).isNotNull();
+        assertThat(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372" +
+                "63723628763821638923628193612983618293628763"))
+                .isEqualTo(valueRead);
     }
     
     /**
@@ -113,8 +114,8 @@ public class NumberConverterTest {
     public void testConvert_PositiveInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.double.pi", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(Double.POSITIVE_INFINITY, valueRead.doubleValue(),0.0d);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead.doubleValue()).isCloseTo(Double.POSITIVE_INFINITY, within(0.0d));
     }
 
     /**
@@ -126,8 +127,8 @@ public class NumberConverterTest {
     public void testConvert_NegativeInfinityValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.double.ni", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(Double.NEGATIVE_INFINITY, valueRead.doubleValue(),0.0d);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead.doubleValue()).isCloseTo(Double.NEGATIVE_INFINITY, within(0.0d));
     }
    
     /**
@@ -139,8 +140,8 @@ public class NumberConverterTest {
     public void testConvert_NaNValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Number valueRead = config.get("tests.converter.double.nan", Number.class);
-        assertNotNull(valueRead);
-        assertEquals(Double.NaN, valueRead.doubleValue(),0.0d);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead.doubleValue()).isCloseTo(Double.NaN, within(0.0d));
     }
         
     @Test(expected = ConfigException.class)
@@ -155,15 +156,15 @@ public class NumberConverterTest {
         NumberConverter converter = new NumberConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("<double>, <long> (NumberConverter)"));
-        assertTrue(context.getSupportedFormats().contains("POSITIVE_INFINITY (NumberConverter)"));
-        assertTrue(context.getSupportedFormats().contains("NEGATIVE_INFINITY (NumberConverter)"));
-        assertTrue(context.getSupportedFormats().contains("NAN (NumberConverter)"));
+        assertThat(context.getSupportedFormats().contains("<double>, <long> (NumberConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("POSITIVE_INFINITY (NumberConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("NEGATIVE_INFINITY (NumberConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("NAN (NumberConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         NumberConverter instance = new NumberConverter();
-        assertEquals(NumberConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(NumberConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
@@ -28,7 +28,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.OffsetDateTime;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -43,17 +43,17 @@ public class OffsetDateTimeConverterTest {
     public void convert() throws Exception {
         OffsetDateTimeConverter conv = new OffsetDateTimeConverter();
         OffsetDateTime value = conv.convert("2007-12-03T10:15:30+01:00", context);
-        assertEquals(value, OffsetDateTime.parse("2007-12-03T10:15:30+01:00"));
+        assertThat(OffsetDateTime.parse("2007-12-03T10:15:30+01:00")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         OffsetDateTimeConverter conv1 = new OffsetDateTimeConverter();
         OffsetDateTimeConverter conv2 = new OffsetDateTimeConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -62,12 +62,12 @@ public class OffsetDateTimeConverterTest {
         OffsetDateTimeConverter converter = new OffsetDateTimeConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (OffsetDateTimeConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (OffsetDateTimeConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         OffsetDateTimeConverter instance = new OffsetDateTimeConverter();
-        assertEquals(OffsetDateTimeConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(OffsetDateTimeConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.OffsetTime;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -42,17 +42,17 @@ public class OffsetTimeConverterTest {
     public void convert() throws Exception {
         OffsetTimeConverter conv = new OffsetTimeConverter();
         OffsetTime value = conv.convert("10:15:30+01:00", context);
-        assertEquals(value, OffsetTime.parse("10:15:30+01:00"));
+        assertThat(OffsetTime.parse("10:15:30+01:00")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         OffsetTimeConverter conv1 = new OffsetTimeConverter();
         OffsetTimeConverter conv2 = new OffsetTimeConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -61,12 +61,12 @@ public class OffsetTimeConverterTest {
         OffsetTimeConverter converter = new OffsetTimeConverter();
         converter.convert("", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().toString().contains(" (OffsetTimeConverter)"));
+        assertThat(localcontext.getSupportedFormats().toString().contains(" (OffsetTimeConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         OffsetTimeConverter instance = new OffsetTimeConverter();
-        assertEquals(OffsetTimeConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(OffsetTimeConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
@@ -26,15 +26,15 @@ import java.util.Optional;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class OptionalConverterTest {
 
     @Test
     public void nullConversionYieldsEmptyOptional() {
         final Optional<?> result = new OptionalConverter().convert(null, null);
-        assertNotNull(result);
-        assertFalse(result.isPresent());
+        assertThat(result).isNotNull();
+        assertThat(result.isPresent()).isFalse();
     }
 
     @Test(expected = ConfigException.class)
@@ -49,9 +49,9 @@ public class OptionalConverterTest {
         ConversionContext ctx = new ConversionContext.Builder("testOptionalString", listOfStringTypeLiteral).build();
 
         final Optional<String> result = new OptionalConverter().convert("astring", ctx);
-        assertNotNull(result);
-        assertTrue(result.isPresent());
-        assertEquals("astring", result.get());
+        assertThat(result).isNotNull();
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo("astring");
     }
 
     @Test
@@ -63,15 +63,15 @@ public class OptionalConverterTest {
                 .build();
 
         final Optional<Integer> result = new OptionalConverter().convert("11", ctx);
-        assertNotNull(result);
-        assertTrue(result.isPresent());
-        assertEquals(11, result.get().intValue());
+        assertThat(result).isNotNull();
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get().intValue()).isEqualTo(11);
     }
     
     
     @Test
     public void testHashCode() {
         OptionalConverter instance = new OptionalConverter();
-        assertEquals(OptionalConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(OptionalConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsti on 02.10.2017.
@@ -43,33 +43,33 @@ public class PathConverterTest {
     public void convert() throws Exception {
         PathConverter conv = new PathConverter();
         Path value = conv.convert("testRoot", context);
-        assertEquals(value, Paths.get("testRoot"));
+        assertThat(Paths.get("testRoot")).isEqualTo(value);
         value = conv.convert("foo", context);
-        assertNotNull(value);
+        assertThat(value).isNotNull();
     }
 
     @Test
     public void convertNull() throws Exception {
         PathConverter conv = new PathConverter();
         Path value = conv.convert(null, context);
-        assertNull(value);
+        assertThat(value).isNull();
         value = conv.convert("", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
     
     @Test
     public void convertInvalidPath() throws Exception {
         PathConverter conv = new PathConverter();
         Path value = conv.convert("/invalid:/\u0000", context);
-        assertNull(value);
+        assertThat(value).isNull();
     }
 
     @Test
     public void equalsAndHashcode() throws Exception {
         PathConverter conv1 = new PathConverter();
         PathConverter conv2 = new PathConverter();
-        assertEquals(conv1, conv2);
-        assertEquals(conv1.hashCode(), conv2.hashCode());
+        assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 
     @Test
@@ -77,13 +77,13 @@ public class PathConverterTest {
         ConversionContext localcontext = new ConversionContext.Builder(TypeLiteral.of(Path.class)).build();
         PathConverter converter = new PathConverter();
         converter.convert("notempty", localcontext);
-        assertTrue(localcontext.getSupportedFormats().contains("<File> (PathConverter)"));
+        assertThat(localcontext.getSupportedFormats().contains("<File> (PathConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         PathConverter instance = new PathConverter();
-        assertEquals(PathConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(PathConverter.class.hashCode());
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the default converter for Shorts.
@@ -41,8 +41,8 @@ public class ShortConverterTest {
     public void testConvert_Short_Decimal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.decimal", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), 101);
+        assertThat(valueRead != null).isTrue();
+        assertThat(101).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -54,8 +54,8 @@ public class ShortConverterTest {
     public void testConvert_Short_Octal() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.octal", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Short.decode("02").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Short.decode("02").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -67,11 +67,11 @@ public class ShortConverterTest {
     public void testConvert_Short_Hex() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.hex.lowerX", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Short.decode("0x2F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Short.decode("0x2F").intValue()).isEqualTo(valueRead.intValue());
         valueRead = config.get("tests.converter.short.hex.upperX", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(valueRead.intValue(), Short.decode("0X3F").intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(Short.decode("0X3F").intValue()).isEqualTo(valueRead.intValue());
     }
 
     /**
@@ -83,7 +83,7 @@ public class ShortConverterTest {
     public void testConvert_NotPresent() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.foo", Short.class);
-        assertFalse(valueRead != null);
+        assertThat(valueRead != null).isFalse();
     }
 
     /**
@@ -95,8 +95,8 @@ public class ShortConverterTest {
     public void testConvert_Short_MinValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.min", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(Short.MIN_VALUE, valueRead.intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.intValue()).isEqualTo(Short.MIN_VALUE);
     }
 
     /**
@@ -108,8 +108,8 @@ public class ShortConverterTest {
     public void testConvert_Short_MaxValue() throws Exception {
         Configuration config = ConfigurationProvider.getConfiguration();
         Short valueRead = config.get("tests.converter.short.max", Short.class);
-        assertTrue(valueRead != null);
-        assertEquals(Short.MAX_VALUE, valueRead.intValue());
+        assertThat(valueRead != null).isTrue();
+        assertThat(valueRead.intValue()).isEqualTo(Short.MAX_VALUE);
     }
     
         
@@ -125,14 +125,14 @@ public class ShortConverterTest {
         ShortConverter converter = new ShortConverter();
         converter.convert("", context);
 
-        assertTrue(context.getSupportedFormats().contains("short (ShortConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MIN_VALUE (ShortConverter)"));
-        assertTrue(context.getSupportedFormats().contains("MAX_VALUE (ShortConverter)"));
+        assertThat(context.getSupportedFormats().contains("short (ShortConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MIN_VALUE (ShortConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().contains("MAX_VALUE (ShortConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         ShortConverter instance = new ShortConverter();
-        assertEquals(ShortConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(ShortConverter.class.hashCode());
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
@@ -26,7 +26,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.apache.tamaya.spi.PropertyConverter;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Matchers.any;
 import org.mockito.Mockito;
 
@@ -47,10 +47,10 @@ public class SupplierConverterTest {
         ConversionContext stringContext = new ConversionContext.Builder(listStringTypeLiteral).build();
         
         stringResult = instance.convert(null, stringContext);
-        assertNull(stringResult.get());
+        assertThat(stringResult.get()).isNull();
         
         stringResult = instance.convert("aString", stringContext);
-        assertEquals("aString", stringResult.get());
+        assertThat(stringResult.get()).isEqualTo("aString");
         
         Supplier<InetAddress> addressResult;
         
@@ -63,14 +63,14 @@ public class SupplierConverterTest {
                 .build();
 
         addressResult = instance.convert("someKey", myConverterContext);
-        assertTrue(addressResult.get() instanceof InetAddress);
+        assertThat(addressResult.get() instanceof InetAddress).isTrue();
 
 }
         
     @Test
     public void testHashCode(){
         SupplierConverter instance = new SupplierConverter();
-        assertEquals(SupplierConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(SupplierConverter.class.hashCode());
     }
 
     private class MyConverter<T extends InetAddress> implements PropertyConverter<InetAddress> {

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
@@ -25,11 +25,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import org.apache.tamaya.ConfigException;
-import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests conversion of the {@link URI}-converter.
@@ -42,38 +38,38 @@ public class URIConverterTest {
     @Test
     public void testConvert_URI() throws Exception {
         URIConverter converter = new URIConverter();
-        assertEquals(new URI("test:path"), converter.convert("test:path", context));
+         assertThat(new URI("test:path")).isEqualTo(converter.convert("test:path", context));
     }
 
     @Test
     public void testConvert_URI_WithSpaces() throws Exception {
         URIConverter converter = new URIConverter();
-        assertEquals(new URI("test:path"), converter.convert("  test:path\t", context));
+        assertThat(new URI("test:path")).isEqualTo(converter.convert("  test:path\t", context));
     }
 
     @Test
     public void testConvert_URI_WithSpacesBefore() throws Exception {
         URIConverter converter = new URIConverter();
-        assertEquals(new URI("test:path"), converter.convert("  test:path", context));
+        assertThat(new URI("test:path")).isEqualTo(converter.convert("  test:path", context));
     }
 
     @Test
     public void testConvert_URI_WithSpacesAfter() throws Exception {
         URIConverter converter = new URIConverter();
-        assertEquals(new URI("test:path"), converter.convert("test:path  ", context));
+        assertThat(new URI("test:path")).isEqualTo(converter.convert("test:path  ", context));
     }
 
     @Test
     public void testConvert_NotPresent() throws Exception {
         URIConverter converter = new URIConverter();
-        assertNull(converter.convert("", context));
-        assertNull(converter.convert(null, context));
+        assertThat(converter.convert("", context)).isNull();
+        assertThat(converter.convert(null, context)).isNull();
     }
     
     @Test
     public void testConvert_URIInvalid() throws ConfigException {
         URIConverter converter = new URIConverter();
-        assertNull(converter.convert("not a uri", context));
+        assertThat(converter.convert("not a uri", context)).isNull();
     }
 
     @Test
@@ -82,13 +78,13 @@ public class URIConverterTest {
         URIConverter converter = new URIConverter();
         converter.convert("test:path", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().contains("<uri> -> new URI(uri) (URIConverter)"));
+        assertThat(localcontext.getSupportedFormats().contains("<uri> -> new URI(uri) (URIConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         URIConverter instance = new URIConverter();
-        assertEquals(URIConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(URIConverter.class.hashCode());
     }
     
     

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
@@ -26,11 +26,7 @@ import java.net.URI;
 import java.net.URL;
 
 import org.apache.tamaya.ConfigException;
-import org.apache.tamaya.Configuration;
-import org.apache.tamaya.ConfigurationProvider;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests conversion of the {@link URL}-converter.
@@ -43,38 +39,38 @@ public class URLConverterTest {
     @Test
     public void testConvert_URL() throws Exception {
         URLConverter converter = new URLConverter();
-        assertEquals(new URL("http://google.com:4000/path"), converter.convert("http://google.com:4000/path", context));
+        assertThat(new URL("http://apache.org:4000/path")).isEqualTo(converter.convert("http://apache.org:4000/path", context));
     }
 
     @Test
     public void testConvert_URL_WithSpaces() throws Exception {
         URLConverter converter = new URLConverter();
-        assertEquals(new URL("http://google.com:4000/path"), converter.convert("  http://google.com:4000/path\t", context));
+        assertThat(new URL("http://apache.org:4000/path")).isEqualTo(converter.convert("  http://apache.org:4000/path\t", context));
     }
 
     @Test
     public void testConvert_URL_WithSpacesBefore() throws Exception {
         URLConverter converter = new URLConverter();
-        assertEquals(new URL("http://google.com:4000/path"), converter.convert("  http://google.com:4000/path", context));
+        assertThat(new URL("http://apache.org:4000/path")).isEqualTo(converter.convert("  http://apache.org:4000/path", context));
     }
 
     @Test
     public void testConvert_URL_WithSpacesAfter() throws Exception {
         URLConverter converter = new URLConverter();
-        assertEquals(new URL("http://google.com:4000/path"), converter.convert("http://google.com:4000/path  ", context));
+        assertThat(new URL("http://apache.org:4000/path")).isEqualTo(converter.convert("http://apache.org:4000/path  ", context));
     }
 
     @Test
     public void testConvert_NotPresent() throws Exception {
         URLConverter converter = new URLConverter();
-        assertNull(converter.convert("", context));
-        assertNull(converter.convert(null, context));
+        assertThat(converter.convert("", context)).isNull();
+        assertThat(converter.convert(null, context)).isNull();
     }
     
     @Test
     public void testConvert_URLInvalid() throws ConfigException {
         URLConverter converter = new URLConverter();
-        assertNull(converter.convert("not a url", context));
+        assertThat(converter.convert("not a url", context)).isNull();
     }
 
     @Test
@@ -83,12 +79,12 @@ public class URLConverterTest {
         URLConverter converter = new URLConverter();
         converter.convert("http://localhost", localcontext);
 
-        assertTrue(localcontext.getSupportedFormats().contains("<URL> (URLConverter)"));
+        assertThat(localcontext.getSupportedFormats().contains("<URL> (URLConverter)")).isTrue();
     }
 
     @Test
     public void testHashCode() {
         URLConverter instance = new URLConverter();
-        assertEquals(URLConverter.class.hashCode(), instance.hashCode());
+        assertThat(instance.hashCode()).isEqualTo(URLConverter.class.hashCode());
     }
 }

--- a/code/spi-support/pom.xml
+++ b/code/spi-support/pom.xml
@@ -50,10 +50,6 @@ under the License.
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceProviderTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.spisupport.propertysource.BuildablePropertySource;
 import org.apache.tamaya.spisupport.propertysource.BuildablePropertySourceProvider;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class BuildablePropertySourceProviderTest {
 
@@ -38,10 +38,10 @@ public class BuildablePropertySourceProviderTest {
                 .withPropertySourcs(ps1)
                 .withPropertySourcs(Arrays.asList(ps2))
                 .build();
-        assertNotNull(prov);
+        assertThat(prov).isNotNull();
         Iterator testable = prov.getPropertySources().iterator();
-        assertEquals(testable.next(), ps1);
-        assertEquals(testable.next(), ps2);
+        assertThat(ps1).isEqualTo(testable.next());
+        assertThat(ps2).isEqualTo(testable.next());
     }
 
     @Test
@@ -57,11 +57,11 @@ public class BuildablePropertySourceProviderTest {
         BuildablePropertySourceProvider prov3 = BuildablePropertySourceProvider.builder()
                 .withPropertySourcs(ps2).build();
         
-        assertEquals(prov1, prov1);
-        assertEquals(prov1, prov2);
-        assertNotEquals(prov1, prov3);
-        assertNotEquals(prov1, null);
-        assertNotEquals(prov1, "aString");
+        assertThat(prov1).isEqualTo(prov1);
+        assertThat(prov2).isEqualTo(prov1);
+        assertThat(prov1).isNotEqualTo(prov3);
+        assertThat(prov1).isNotEqualTo(null);
+        assertThat(prov1).isNotEqualTo("aString");
     }
 
     @Test
@@ -72,19 +72,19 @@ public class BuildablePropertySourceProviderTest {
                 .withPropertySourcs(ps).build();
         BuildablePropertySourceProvider prov2 = BuildablePropertySourceProvider.builder()
                 .withPropertySourcs(ps).build();
-        assertEquals(prov1.hashCode(), prov2.hashCode());
+        assertThat(prov2.hashCode()).isEqualTo(prov1.hashCode());
         BuildablePropertySource ps2 = BuildablePropertySource.builder()
                 .withName("test12").build();
         prov2 = BuildablePropertySourceProvider.builder()
                 .withPropertySourcs(ps2).build();
-        assertNotEquals(prov1.hashCode(), prov2.hashCode());
+        assertThat(prov1.hashCode()).isNotEqualTo(prov2.hashCode());
     }
 
 
     @Test
     public void builder() throws Exception {
-        assertNotNull(BuildablePropertySource.builder());
-        assertNotEquals(BuildablePropertySource.builder(), BuildablePropertySource.builder());
+        assertThat(BuildablePropertySource.builder()).isNotNull();
+        assertThat(BuildablePropertySource.builder()).isNotEqualTo(BuildablePropertySource.builder());
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceTest.java
@@ -24,45 +24,45 @@ import org.apache.tamaya.spi.PropertyValue;
 import org.apache.tamaya.spisupport.propertysource.BuildablePropertySource;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class BuildablePropertySourceTest {
     @Test
     public void getOrdinal() throws Exception {
         BuildablePropertySource ps1 = BuildablePropertySource.builder()
                 .withOrdinal(55).build();
-        assertEquals(55, ps1.getOrdinal());
+        assertThat(ps1.getOrdinal()).isEqualTo(55);
     }
 
     @Test
     public void getName() throws Exception {
         BuildablePropertySource ps1 = BuildablePropertySource.builder()
                 .withName("test1").build();
-        assertEquals("test1", ps1.getName());
+        assertThat(ps1.getName()).isEqualTo("test1");
         ps1 = BuildablePropertySource.builder().build();
-        assertNotNull(ps1.getName());
+        assertThat(ps1.getName()).isNotNull();
     }
 
     @Test
     public void get() throws Exception {
         BuildablePropertySource ps1 = BuildablePropertySource.builder()
                 .withSimpleProperty("a", "b").build();
-        assertEquals("b", ps1.get("a").getValue());
+        assertThat(ps1.get("a").getValue()).isEqualTo("b");
     }
     
     @Test
     public void getProperties() throws Exception {
         BuildablePropertySource ps1 = BuildablePropertySource.builder()
                 .withSimpleProperty("a", "b").build();
-        assertNotNull(ps1.getProperties());
-        assertEquals(1, ps1.getProperties().size());
-        assertEquals("b", ps1.getProperties().get("a").getValue());
+        assertThat(ps1.getProperties()).isNotNull();
+        assertThat(ps1.getProperties()).hasSize(1);
+        assertThat(ps1.getProperties().get("a").getValue()).isEqualTo("b");
     }
     
     @Test
     public void testScannable() {
         BuildablePropertySource bps = BuildablePropertySource.builder().build();
-        assertTrue(bps.isScannable());
+        assertThat(bps.isScannable()).isTrue();
     }
     
     @Test
@@ -73,8 +73,8 @@ public class BuildablePropertySourceTest {
                 .withSimpleProperty("namedSourceKey", "namedSourceValue", "namedSource")
                 .build();
         
-        assertEquals("fakeSource", bps.get("defaultSourceKey").getSource());
-        assertEquals("namedSource", bps.get("namedSourceKey").getSource());
+        assertThat(bps.get("defaultSourceKey").getSource()).isEqualTo("fakeSource");
+        assertThat(bps.get("namedSourceKey").getSource()).isEqualTo("namedSource");
     }
     
     @Test
@@ -94,11 +94,11 @@ public class BuildablePropertySourceTest {
                 .withProperties(propertyThird)
                 .build();
         
-        assertNull(bps.get("firstKey"));
-        assertNull(bps.get("secondKey"));
-        assertEquals("thirdValue", bps.get("thirdKey").getValue());
-        assertEquals("thirdSource", bps.get("thirdKey").getSource());
-        assertNull(bps.get("thirdPVKey"));
+        assertThat(bps.get("firstKey")).isNull();
+        assertThat(bps.get("secondKey")).isNull();
+        assertThat(bps.get("thirdKey").getValue()).isEqualTo("thirdValue");
+        assertThat(bps.get("thirdKey").getSource()).isEqualTo("thirdSource");
+        assertThat(bps.get("thirdPVKey")).isNull();
         
         bps = BuildablePropertySource.builder()
                 .withProperties(propertyThird)
@@ -106,12 +106,12 @@ public class BuildablePropertySourceTest {
                 .withProperties(propertySecond, "secondSource")
                 .build();
         
-        assertEquals("firstValue", bps.get("firstKey").getValue());
-        assertEquals("secondSource", bps.get("secondKey").getSource());
-        assertEquals("secondValue", bps.get("secondKey").getValue());
-        assertEquals("thirdValue", bps.get("thirdKey").getValue());
-        assertEquals("thirdSource", bps.get("thirdKey").getSource());
-        assertNull(bps.get("thirdPVKey"));
+        assertThat(bps.get("firstKey").getValue()).isEqualTo("firstValue");
+        assertThat(bps.get("secondKey").getSource()).isEqualTo("secondSource");
+        assertThat(bps.get("secondKey").getValue()).isEqualTo("secondValue");
+        assertThat(bps.get("thirdKey").getValue()).isEqualTo("thirdValue");
+        assertThat(bps.get("thirdKey").getSource()).isEqualTo("thirdSource");
+        assertThat(bps.get("thirdPVKey")).isNull();
     }
 
     @Test
@@ -120,12 +120,12 @@ public class BuildablePropertySourceTest {
                 .withName("test1").build();
         BuildablePropertySource ps2 = BuildablePropertySource.builder()
                 .withName("test1").build();
-        assertEquals(ps1, ps2);
+        assertThat(ps2).isEqualTo(ps1);
         ps2 = BuildablePropertySource.builder()
                 .withName("test2").build();
-        assertNotEquals(ps1, ps2);
-        assertNotEquals(ps2, null);
-        assertNotEquals(ps1, "aString");
+        assertThat(ps1).isNotEqualTo(ps2);
+        assertThat(ps2).isNotEqualTo(null);
+        assertThat(ps1).isNotEqualTo("aString");
     }
 
     @Test
@@ -134,17 +134,17 @@ public class BuildablePropertySourceTest {
                 .withName("test1").build();
         BuildablePropertySource ps2 = BuildablePropertySource.builder()
                 .withName("test1").build();
-        assertEquals(ps1.hashCode(), ps2.hashCode());
+        assertThat(ps2.hashCode()).isEqualTo(ps1.hashCode());
         ps2 = BuildablePropertySource.builder()
                 .withName("test2").build();
-        assertNotEquals(ps1.hashCode(), ps2.hashCode());
+        assertThat(ps1.hashCode()).isNotEqualTo(ps2.hashCode());
     }
 
     @Test
     public void builder() throws Exception {
-        assertNotNull(BuildablePropertySource.builder());
-        assertNotNull(BuildablePropertySource.builder().but());
-        assertNotEquals(BuildablePropertySource.builder(), BuildablePropertySource.builder());
+        assertThat(BuildablePropertySource.builder()).isNotNull();
+        assertThat(BuildablePropertySource.builder().but()).isNotNull();
+        assertThat(BuildablePropertySource.builder()).isNotEqualTo(BuildablePropertySource.builder());
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
@@ -23,7 +23,7 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -40,9 +40,9 @@ public class DefaultConfigValueEvaluatorTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         DefaultConfigValueEvaluator instance = new DefaultConfigValueEvaluator();
         PropertyValue result = instance.evaluteRawValue("confkey1", config.getContext());
-        assertEquals("javaconf-value1", result.getValue());
+        assertThat(result.getValue()).isEqualTo("javaconf-value1");
         result = instance.evaluteRawValue("missing", config.getContext());
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     /**
@@ -53,8 +53,8 @@ public class DefaultConfigValueEvaluatorTest {
         Configuration config = ConfigurationProvider.getConfiguration();
         DefaultConfigValueEvaluator instance = new DefaultConfigValueEvaluator();
         Map<String, PropertyValue> result = instance.evaluateRawValues(config.getContext());
-        assertTrue(result.containsKey("confkey1"));
-        assertEquals("javaconf-value1", result.get("confkey1").getValue());
+        assertThat(result.containsKey("confkey1")).isTrue();
+        assertThat(result.get("confkey1").getValue()).isEqualTo("javaconf-value1");
     }
 
     

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link  DefaultConfigurationBuilder} by atsticks on 06.09.16.
@@ -46,7 +46,7 @@ public class DefaultConfigurationBuilderTest {
         ConfigurationContext context = ConfigurationProvider.getConfiguration().getContext();
         ConfigurationBuilder b = new DefaultConfigurationBuilder()
                 .setContext(context);
-        assertEquals(context, b.build().getContext());
+        assertThat(b.build().getContext()).isEqualTo(context);
     }
 
     @Test
@@ -54,7 +54,7 @@ public class DefaultConfigurationBuilderTest {
         Configuration cfg = ConfigurationProvider.getConfiguration();
         ConfigurationBuilder b = new DefaultConfigurationBuilder()
                 .setConfiguration(cfg);
-        assertEquals(cfg, b.build());
+        assertThat(b.build()).isEqualTo(cfg);
     }
 
     @Test
@@ -64,17 +64,17 @@ public class DefaultConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
 
         b = new DefaultConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         cfg = b.removePropertySources(testPropertySource).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertySources().size());
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(1);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -84,17 +84,17 @@ public class DefaultConfigurationBuilderTest {
                 .addPropertySources(Arrays.asList(testPropertySource, testPS2));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
 
         b = new DefaultConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         cfg = b.removePropertySources(Arrays.asList(testPropertySource)).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertySources().size());
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
+        assertThat(ctx.getPropertySources()).hasSize(1);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
     }
 
     @Test
@@ -104,23 +104,23 @@ public class DefaultConfigurationBuilderTest {
         DefaultConfigurationBuilder b = new DefaultConfigurationBuilder();
         Configuration cfg = b.addPropertyFilters(filter1, filter2).build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         cfg = b.addPropertyFilters(filter1, filter2).build();
         ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         cfg = b.removePropertyFilters(filter1).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
 
     }
 
@@ -131,23 +131,23 @@ public class DefaultConfigurationBuilderTest {
         DefaultConfigurationBuilder b = new DefaultConfigurationBuilder();
         Configuration cfg = b.addPropertyFilters(Arrays.asList(filter1, filter2)).build();
         ConfigurationContext ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(Arrays.asList(filter1, filter2, filter1));
         cfg = b.addPropertyFilters(Arrays.asList(filter1, filter2)).build();
         ctx = cfg.getContext();
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(Arrays.asList(filter1, filter2));
         cfg = b.removePropertyFilters(Arrays.asList(filter1)).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
 
     }
 
@@ -161,21 +161,21 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertySources(propertySources);
         b.increasePriority(propertySources[propertySources.length - 1]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.increasePriority(propertySources[propertySources.length - 2]).build();
         for (int i = 0; i < propertySources.length - 2; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length - 1], b.getPropertySources().get(propertySources.length - 2));
-        assertEquals(propertySources[propertySources.length - 2], b.getPropertySources().get(propertySources.length - 1));
+        assertThat(b.getPropertySources().get(propertySources.length - 2)).isEqualTo(propertySources[propertySources.length - 1]);
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[propertySources.length - 2]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.increasePriority(propertySources[propertySources.length - 2]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -188,21 +188,21 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertySources(propertySources);
         b.decreasePriority(propertySources[0]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.decreasePriority(propertySources[1]).build();
         for (int i = 2; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.decreasePriority(propertySources[1]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -217,23 +217,23 @@ public class DefaultConfigurationBuilderTest {
         // test
         b.lowestPriority(propertySources[0]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.lowestPriority(propertySources[1]);
         for (int i = 2; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         b.lowestPriority(propertySources[5]).build();
-        assertEquals(propertySources[5], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[5]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.lowestPriority(propertySources[5]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -248,23 +248,23 @@ public class DefaultConfigurationBuilderTest {
         // test
         b.highestPriority(propertySources[propertySources.length - 1]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.highestPriority(propertySources[propertySources.length - 2]);
         for (int i = 0; i < propertySources.length - 2; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length - 2], b.getPropertySources().get(propertySources.length - 1));
-        assertEquals(propertySources[propertySources.length - 1], b.getPropertySources().get(propertySources.length - 2));
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[propertySources.length - 2]);
+        assertThat(b.getPropertySources().get(propertySources.length - 2)).isEqualTo(propertySources[propertySources.length - 1]);
         b.highestPriority(propertySources[5]).build();
-        assertEquals(propertySources[5], b.getPropertySources().get(propertySources.length - 1));
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[5]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.highestPriority(propertySources[5]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -278,10 +278,10 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertySources(propertySources);
         Comparator<PropertySource> psComp = (o1, o2) -> o1.toString().compareTo(o2.toString());
         // test 
-        assertEquals(DefaultConfigurationBuilder.class, b.sortPropertySources(psComp).getClass());
+        assertThat(b.sortPropertySources(psComp).getClass()).isEqualTo(DefaultConfigurationBuilder.class);
         Arrays.sort(propertySources, psComp);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
     }
 
@@ -297,10 +297,10 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertyFilters(propertyFilters);
         Comparator<PropertyFilter> pfComp = (o1, o2) -> o1.toString().compareTo(o2.toString());
         //test
-        assertEquals(DefaultConfigurationBuilder.class, b.sortPropertyFilter(pfComp).getClass());
+        assertThat(b.sortPropertyFilter(pfComp).getClass()).isEqualTo(DefaultConfigurationBuilder.class);
         Arrays.sort(propertyFilters, pfComp);
         for (int i = 0; i < propertyFilters.length; i++) {
-            assertEquals(propertyFilters[i], b.getPropertyFilters().get(i));
+            assertThat(b.getPropertyFilters().get(i)).isEqualTo(propertyFilters[i]);
         }
     }
 
@@ -313,29 +313,29 @@ public class DefaultConfigurationBuilderTest {
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
         Map<TypeLiteral<?>, Collection<PropertyConverter<?>>> buildConverters = b.getPropertyConverter();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2));
-        assertEquals(1, ctx.getPropertyConverters().size());
-        assertEquals(2, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
-        assertTrue(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
-                        ctx.getPropertyConverters().get(TypeLiteral.of(String.class))));
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2);
+        assertThat(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
+                        ctx.getPropertyConverters().get(TypeLiteral.of(String.class)))).isTrue();
 
         b = new DefaultConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter1);
         cfg = b.addPropertyConverters(TypeLiteral.of(String.class), converter1).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), converter1, converter2);
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class), converter1).build();
         ctx = cfg.getContext();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2));
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), converter1, converter2);
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class)).build();
         ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -347,29 +347,29 @@ public class DefaultConfigurationBuilderTest {
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
         Map<TypeLiteral<?>, Collection<PropertyConverter<?>>> buildConverters = b.getPropertyConverter();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2));
-        assertEquals(1, ctx.getPropertyConverters().size());
-        assertEquals(2, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
-        assertTrue(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
-                        ctx.getPropertyConverters().get(TypeLiteral.of(String.class))));
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2);
+        assertThat(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
+                        ctx.getPropertyConverters().get(TypeLiteral.of(String.class)))).isTrue();
 
         b = new DefaultConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1));
         cfg = b.addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1)).build();
         ctx = cfg.getContext();
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1, converter2));
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1)).build();
         ctx = cfg.getContext();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2));
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1, converter2));
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class)).build();
         ctx = cfg.getContext();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -379,12 +379,12 @@ public class DefaultConfigurationBuilderTest {
                 .setPropertyValueCombinationPolicy(combPol);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertEquals(ctx.getPropertyValueCombinationPolicy(), combPol);
+        assertThat(combPol).isEqualTo(ctx.getPropertyValueCombinationPolicy());
     }
 
     @Test
     public void build() throws Exception {
-        assertNotNull(new DefaultConfigurationBuilder().build());
+        assertThat(new DefaultConfigurationBuilder().build()).isNotNull();
     }
 
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextBuilderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextBuilderTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.apache.tamaya.spi.PropertyFilter;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValueCombinationPolicy;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
@@ -54,16 +54,16 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContext context = ConfigurationProvider.getConfiguration().getContext();
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .setContext(context);
-        assertEquals(context, b.build());
+        assertThat(b.build()).isEqualTo(context);
         boolean caughtAlreadyBuilt = false;
         try {
             b.setContext(context);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
         b = new DefaultConfigurationContextBuilder(context);
-        assertEquals(context, b.build());
+        assertThat(b.build()).isEqualTo(context);
     }
 
     @Test
@@ -72,22 +72,22 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new MockedPropertySource("addPropertySources_Array", 1);
         b = new DefaultConfigurationContextBuilder();
         ctx = b.addPropertySources(testPS2, testPropertySource).build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
-        assertEquals(ctx.getPropertySources().get(1).getName(), "MockedPropertySource");
-        assertEquals(ctx.getPropertySources().get(0).getName(), "addPropertySources_Array");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
+        assertThat("MockedPropertySource").isEqualTo(ctx.getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Array").isEqualTo(ctx.getPropertySources().get(0).getName());
     }
 
     @Test
@@ -96,24 +96,24 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPropertySource, testPS2}));
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
-        assertEquals(ctx.getPropertySources().get(0).getName(), "MockedPropertySource");
-        assertEquals(ctx.getPropertySources().get(1).getName(), "addPropertySources_Collection");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
+        assertThat("MockedPropertySource").isEqualTo(ctx.getPropertySources().get(0).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(ctx.getPropertySources().get(1).getName());
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new MockedPropertySource("addPropertySources_Collection", 1);
         ctx = new DefaultConfigurationContextBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPS2, testPropertySource})).build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
-        assertEquals(ctx.getPropertySources().get(1).getName(), "MockedPropertySource");
-        assertEquals(ctx.getPropertySources().get(0).getName(), "addPropertySources_Collection");
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
+        assertThat("MockedPropertySource").isEqualTo(ctx.getPropertySources().get(1).getName());
+        assertThat("addPropertySources_Collection").isEqualTo(ctx.getPropertySources().get(0).getName());
     }
 
     @Test
@@ -122,20 +122,20 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
         b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ctx = b.removePropertySources(testPropertySource).build();
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
         //Throws an exception
-        //assertNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName()));
-        assertEquals(1, ctx.getPropertySources().size());
+        //assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPS2.getName())).isNotNull();
+        assertThat(ctx.getPropertySources()).hasSize(1);
     }
 
     @Test
@@ -144,18 +144,18 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ConfigurationContext ctx = b.build();
-        assertEquals(2, ctx.getPropertySources().size());
-        assertTrue(ctx.getPropertySources().contains(testPropertySource));
-        assertNotNull(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName()));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(ctx.getPropertySource(testPS2.getName()));
+        assertThat(ctx.getPropertySources()).hasSize(2);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource(testPropertySource.getName())).isNotNull();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySource(testPS2.getName())).isNotNull();
         b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         ctx = b.removePropertySources(testPropertySource).build();
-        assertEquals(1, ctx.getPropertySources().size());
-        assertFalse(ctx.getPropertySources().contains(testPropertySource));
-        assertTrue(ctx.getPropertySources().contains(testPS2));
-        assertNotNull(ctx.getPropertySource(testPS2.getName()));
+        assertThat(ctx.getPropertySources()).hasSize(1);
+        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
+        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySource(testPS2.getName())).isNotNull();
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -163,7 +163,7 @@ public class DefaultConfigurationContextBuilderTest {
         PropertySource testPS2 = new MockedPropertySource("removePropertySources_Array", 1);
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertySources(testPropertySource, testPS2);
-        assertNull(((DefaultConfigurationContextBuilder)b).getPropertySource("missing"));
+        assertThat(((DefaultConfigurationContextBuilder)b).getPropertySource("missing")).isNull();
     }
 
     @Test
@@ -179,14 +179,14 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(caughtAlreadyBuilt).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new DefaultConfigurationContextBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -202,14 +202,14 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(caughtAlreadyBuilt).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new DefaultConfigurationContextBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
     }
 
     @Test
@@ -219,22 +219,22 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertyFilters(filter1, filter2);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyFilters(filter1, filter2);
         ctx = b.removePropertyFilters(filter1).build();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
         boolean caughtAlreadyBuilt = false;
         try {
             b.removePropertyFilters(filter1);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -244,22 +244,22 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
-        assertEquals(2, ctx.getPropertyFilters().size());
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(2);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         ctx = b.removePropertyFilters(Arrays.asList(filter1)).build();
-        assertEquals(1, ctx.getPropertyFilters().size());
-        assertFalse(ctx.getPropertyFilters().contains(filter1));
-        assertTrue(ctx.getPropertyFilters().contains(filter2));
+        assertThat(ctx.getPropertyFilters()).hasSize(1);
+        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
+        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
         boolean caughtAlreadyBuilt = false;
         try {
             b.removePropertyFilters(filter1);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -275,13 +275,13 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(caughtAlreadyBuilt).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(1, ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
     }
 
     @Test
@@ -299,14 +299,14 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(caughtAlreadyBuilt).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertEquals(ctx.getPropertyConverters().size(), 1);
+        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
     }
     
     @Test
@@ -316,13 +316,13 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ctx = b.removePropertyConverters(TypeLiteral.of(String.class)).build();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -332,13 +332,13 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         ctx = b.removePropertyConverters(TypeLiteral.of(String.class), converter).build();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -348,13 +348,13 @@ public class DefaultConfigurationContextBuilderTest {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         ConfigurationContext ctx = b.build();
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertEquals(1, ctx.getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
         b = new DefaultConfigurationContextBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         ctx = b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter})).build();
-        assertFalse(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter));
-        assertTrue(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
     }
 
     @Test
@@ -369,8 +369,8 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
-        assertEquals(ctx.getPropertyValueCombinationPolicy(), combPol);
+        assertThat(caughtAlreadyBuilt).isTrue();
+        assertThat(combPol).isEqualTo(ctx.getPropertyValueCombinationPolicy());
     }
 
     @Test
@@ -383,21 +383,21 @@ public class DefaultConfigurationContextBuilderTest {
         b.addPropertySources(propertySources);
         b.increasePriority(propertySources[propertySources.length - 1]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.increasePriority(propertySources[propertySources.length - 2]).build();
         for (int i = 0; i < propertySources.length - 2; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length - 1], b.getPropertySources().get(propertySources.length - 2));
-        assertEquals(propertySources[propertySources.length - 2], b.getPropertySources().get(propertySources.length - 1));
+        assertThat(b.getPropertySources().get(propertySources.length - 2)).isEqualTo(propertySources[propertySources.length - 1]);
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[propertySources.length - 2]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.increasePriority(propertySources[propertySources.length - 2]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -410,21 +410,21 @@ public class DefaultConfigurationContextBuilderTest {
         b.addPropertySources(propertySources);
         b.decreasePriority(propertySources[0]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.decreasePriority(propertySources[1]).build();
         for (int i = 2; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.decreasePriority(propertySources[1]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -439,23 +439,23 @@ public class DefaultConfigurationContextBuilderTest {
         // test
         b.lowestPriority(propertySources[0]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.lowestPriority(propertySources[1]);
         for (int i = 2; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[0], b.getPropertySources().get(1));
-        assertEquals(propertySources[1], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(1)).isEqualTo(propertySources[0]);
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[1]);
         b.lowestPriority(propertySources[5]).build();
-        assertEquals(propertySources[5], b.getPropertySources().get(0));
+        assertThat(b.getPropertySources().get(0)).isEqualTo(propertySources[5]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.lowestPriority(propertySources[5]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -470,23 +470,23 @@ public class DefaultConfigurationContextBuilderTest {
         // test
         b.highestPriority(propertySources[propertySources.length - 1]);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
         b.highestPriority(propertySources[propertySources.length - 2]);
         for (int i = 0; i < propertySources.length - 2; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
-        assertEquals(propertySources[propertySources.length - 2], b.getPropertySources().get(propertySources.length - 1));
-        assertEquals(propertySources[propertySources.length - 1], b.getPropertySources().get(propertySources.length - 2));
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[propertySources.length - 2]);
+        assertThat(b.getPropertySources().get(propertySources.length - 2)).isEqualTo(propertySources[propertySources.length - 1]);
         b.highestPriority(propertySources[5]).build();
-        assertEquals(propertySources[5], b.getPropertySources().get(propertySources.length - 1));
+        assertThat(b.getPropertySources().get(propertySources.length - 1)).isEqualTo(propertySources[5]);
         boolean caughtAlreadyBuilt = false;
         try {
             b.highestPriority(propertySources[5]);
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
@@ -500,10 +500,10 @@ public class DefaultConfigurationContextBuilderTest {
         b.addPropertySources(propertySources);
         Comparator<PropertySource> psComp = (o1, o2) -> o1.toString().compareTo(o2.toString());
         // test 
-        assertEquals(DefaultConfigurationContextBuilder.class, b.sortPropertySources(psComp).getClass());
+        assertThat(b.sortPropertySources(psComp).getClass()).isEqualTo(DefaultConfigurationContextBuilder.class);
         Arrays.sort(propertySources, psComp);
         for (int i = 0; i < propertySources.length; i++) {
-            assertEquals(propertySources[i], b.getPropertySources().get(i));
+            assertThat(b.getPropertySources().get(i)).isEqualTo(propertySources[i]);
         }
     }
 
@@ -519,10 +519,10 @@ public class DefaultConfigurationContextBuilderTest {
         b.addPropertyFilters(propertyFilters);
         Comparator<PropertyFilter> pfComp = (o1, o2) -> o1.toString().compareTo(o2.toString());
         //test
-        assertEquals(DefaultConfigurationContextBuilder.class, b.sortPropertyFilter(pfComp).getClass());
+        assertThat(b.sortPropertyFilter(pfComp).getClass()).isEqualTo(DefaultConfigurationContextBuilder.class);
         Arrays.sort(propertyFilters, pfComp);
         for (int i = 0; i < propertyFilters.length; i++) {
-            assertEquals(propertyFilters[i], b.getPropertyFilters().get(i));
+            assertThat(b.getPropertyFilters().get(i)).isEqualTo(propertyFilters[i]);
         }
     }
 
@@ -530,34 +530,34 @@ public class DefaultConfigurationContextBuilderTest {
     public void build() throws Exception {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder();
         ConfigurationContext ctx = b.build();
-        assertNotNull(ctx);
-        assertTrue(ctx.getPropertySources().isEmpty());
-        assertTrue(ctx.getPropertyFilters().isEmpty());
+        assertThat(ctx).isNotNull();
+        assertThat(ctx.getPropertySources().isEmpty()).isTrue();
+        assertThat(ctx.getPropertyFilters().isEmpty()).isTrue();
         boolean caughtAlreadyBuilt = false;
         try {
             b.build();
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
     }
 
     @Test
     public void testRemoveAllFilters() throws Exception {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder();
         b.addPropertyFilters((value, context) -> value.toBuilder().setValue(toString() + " - ").build());
-        assertFalse(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isFalse();
         b.removePropertyFilters(b.getPropertyFilters());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
     public void testRemoveAllSources() throws Exception {
         ConfigurationContextBuilder b = new DefaultConfigurationContextBuilder();
         b.addPropertySources(new MockedPropertySource());
-        assertFalse(b.getPropertySources().isEmpty());
+        assertThat(b.getPropertySources().isEmpty()).isFalse();
         b.removePropertySources(b.getPropertySources());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
     }
 
     @Test
@@ -578,20 +578,20 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
 
         b = new DefaultConfigurationContextBuilder();
         b.addPropertyFilters((value, context) -> value.toBuilder().setValue(toString() + " - ").build());
         b.addPropertySources(new MockedPropertySource());
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.resetWithConfigurationContext(empty);
-        assertTrue(b.getPropertyConverter().isEmpty());
-        assertTrue(b.getPropertySources().isEmpty());
-        assertTrue(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyConverter().isEmpty()).isTrue();
+        assertThat(b.getPropertySources().isEmpty()).isTrue();
+        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
         b.resetWithConfigurationContext(full).build();
-        assertFalse(b.getPropertyConverter().isEmpty());
-        assertFalse(b.getPropertySources().isEmpty());
-        assertFalse(b.getPropertyFilters().isEmpty());
+        assertThat(b.getPropertyConverter().isEmpty()).isFalse();
+        assertThat(b.getPropertySources().isEmpty()).isFalse();
+        assertThat(b.getPropertyFilters().isEmpty()).isFalse();
 
     }
 
@@ -605,12 +605,12 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
 
         ConfigurationContext ctx = new DefaultConfigurationContextBuilder().loadDefaults().build();
-        assertFalse(ctx.getPropertyConverters().isEmpty());
-        assertFalse(ctx.getPropertyFilters().isEmpty());
-        assertFalse(ctx.getPropertySources().isEmpty());
+        assertThat(ctx.getPropertyConverters().isEmpty()).isFalse();
+        assertThat(ctx.getPropertyFilters().isEmpty()).isFalse();
+        assertThat(ctx.getPropertySources().isEmpty()).isFalse();
     }
     
     
@@ -624,11 +624,11 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
 
         ConfigurationContext ctx = new DefaultConfigurationContextBuilder().addDefaultPropertyConverters().build();
-        assertFalse(ctx.getPropertyConverters().isEmpty());
-        assertNotNull(ctx.getPropertyConverters(TypeLiteral.of(Integer.class)));
+        assertThat(ctx.getPropertyConverters().isEmpty()).isFalse();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(Integer.class))).isNotNull();
     }
     
         @Test
@@ -641,10 +641,10 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
 
         ConfigurationContext ctx = new DefaultConfigurationContextBuilder().addDefaultPropertyFilters().build();
-        assertFalse(ctx.getPropertyFilters().isEmpty());
+        assertThat(ctx.getPropertyFilters().isEmpty()).isFalse();
     }
         
         @Test
@@ -657,11 +657,11 @@ public class DefaultConfigurationContextBuilderTest {
         } catch (IllegalStateException e) {
             caughtAlreadyBuilt = true;
         }
-        assertTrue(caughtAlreadyBuilt);
+        assertThat(caughtAlreadyBuilt).isTrue();
 
         ConfigurationContext ctx = new DefaultConfigurationContextBuilder().addDefaultPropertySources().build();
-        assertFalse(ctx.getPropertySources().isEmpty());
-        assertNotNull(ctx.getPropertySource("environment-properties"));
+        assertThat(ctx.getPropertySources().isEmpty()).isFalse();
+        assertThat(ctx.getPropertySource("environment-properties")).isNotNull();
     }
             
         @Test
@@ -669,7 +669,7 @@ public class DefaultConfigurationContextBuilderTest {
         DefaultConfigurationContextBuilder b = new DefaultConfigurationContextBuilder();
         List<PropertySource> ps = new ArrayList<>();
         b.addCorePropertyResources(ps);
-        assertFalse(ps.isEmpty());
+        assertThat(ps.isEmpty()).isFalse();
         
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
@@ -18,16 +18,9 @@
  */
 package org.apache.tamaya.spisupport;
 
-import java.util.List;
-import java.util.Map;
-import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.ConfigurationContextBuilder;
-import org.apache.tamaya.spi.PropertyConverter;
-import org.apache.tamaya.spi.PropertyFilter;
 import org.apache.tamaya.spi.PropertySource;
-import org.apache.tamaya.spi.PropertyValueCombinationPolicy;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -45,15 +38,15 @@ public class DefaultConfigurationContextTest {
         DefaultConfigurationContext ctx3 = (DefaultConfigurationContext) new DefaultConfigurationContextBuilder().build();
         ctx3.addPropertySources(new MockedPropertySource());
 
-        assertEquals(ctx1, ctx1);
-        assertNotEquals(null, ctx1);
-        assertNotEquals("aString", ctx1);
-        assertEquals(ctx1, ctx2);
-        assertNotEquals(ctx1, ctx3);
-        assertEquals(ctx1.hashCode(), ctx2.hashCode());
-        assertNotEquals(ctx1.hashCode(), ctx3.hashCode());
+        assertThat(ctx1).isEqualTo(ctx1);
+        assertThat(ctx1).isNotEqualTo(null);
+        assertThat("aString").isNotEqualTo(ctx1);
+        assertThat(ctx2).isEqualTo(ctx1);
+        assertThat(ctx1).isNotEqualTo(ctx3);
+        assertThat(ctx2.hashCode()).isEqualTo(ctx1.hashCode());
+        assertThat(ctx1.hashCode()).isNotEqualTo(ctx3.hashCode());
         String spaces = new String(new char[70 - sharedSource.getName().length()]).replace("\0", " ");
         System.out.println(ctx1.toString());
-        assertTrue(ctx1.toString().contains(sharedSource.getName() + spaces));
+        assertThat(ctx1.toString().contains(sharedSource.getName() + spaces)).isTrue();
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
@@ -24,7 +24,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
+import org.assertj.core.internal.cglib.core.Predicate;
 
 public class DefaultConfigurationTest {
 
@@ -62,9 +63,9 @@ public class DefaultConfigurationTest {
     @Test
     public void getReturnsNullOrNotAsAppropriate() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertNotNull(c.get("valueOfValid"));
-        assertNull(c.get("valueOfNull"));
-        assertNull(c.get("Filternull")); //get does apply filtering
+        assertThat(c.get("valueOfValid")).isNotNull();
+        assertThat(c.get("valueOfNull")).isNull();
+        assertThat(c.get("Filternull")).isNull(); //get does apply filtering
     }
 
     /**
@@ -98,9 +99,8 @@ public class DefaultConfigurationTest {
     @Test
     public void getOrDefaultDoesAcceptNullAsDefaultValueForThreeParameterVariant() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-
-        assertNotNull(c.getOrDefault("a", String.class, null));
-        assertNotNull(c.getOrDefault("a", TypeLiteral.of(String.class), null));
+        assertThat(c.getOrDefault("a", String.class, null)).isNotNull();
+        assertThat((String) c.getOrDefault("a", TypeLiteral.of(String.class), null)).isNotNull();
     }
 
     @Test(expected = NullPointerException.class)
@@ -123,15 +123,15 @@ public class DefaultConfigurationTest {
     @Test
     public void getOrDefaultDoesAcceptNullAsDefaultValueForTwoParameterVariantDefaultValueIsSecond() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertNotNull(c.getOrDefault("a", null));
+        assertThat(c.getOrDefault("a", null)).isNotNull();
     }
 
     @Test
     public void getOrDefaultReturnDefaultIfValueWouldHaveBeenNull() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertEquals("ok", c.getOrDefault("valueOfNull", "ok"));
-        assertEquals("ok", c.getOrDefault("valueOfNull", String.class, "ok"));
-        assertEquals("ok", c.getOrDefault("valueOfNull", TypeLiteral.of(String.class), "ok"));
+        assertThat("ok").isEqualTo(c.getOrDefault("valueOfNull", "ok"));
+        assertThat("ok").isEqualTo(c.getOrDefault("valueOfNull", String.class, "ok"));
+        assertThat("ok").isEqualTo(c.getOrDefault("valueOfNull", TypeLiteral.of(String.class), "ok"));
     }
 
     /**
@@ -140,9 +140,9 @@ public class DefaultConfigurationTest {
     @Test
     public void evaluateRawValueReturnsNullOrNotAsAppropriate() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertNotNull(c.evaluteRawValue("valueOfValid"));
-        assertNull(c.evaluteRawValue("valueOfNull"));
-        assertNotNull(c.evaluteRawValue("Filternull")); //evaluateRawValue does not apply filtering
+        assertThat(c.evaluteRawValue("valueOfValid")).isNotNull();
+        assertThat(c.evaluteRawValue("valueOfNull")).isNull();
+        assertThat(c.evaluteRawValue("Filternull")).isNotNull(); //evaluateRawValue does not apply filtering
     }
 
     /**
@@ -152,10 +152,10 @@ public class DefaultConfigurationTest {
     public void getPropertiesReturnsNullOrNotAsAppropriate() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
         Map<String, String> result = c.getProperties();
-        assertEquals("valueFromMockedPropertySource", result.get("someKey"));
-        assertNull(result.get("notInThePropertiesMock"));
-        assertNull(result.get("valueOfNull"));
-        assertNull(result.get("Filternull"));
+        assertThat(result.get("someKey")).isEqualTo("valueFromMockedPropertySource");
+        assertThat(result.get("notInThePropertiesMock")).isNull();
+        assertThat(result.get("valueOfNull")).isNull();
+        assertThat(result.get("Filternull")).isNull();
     }
 
     /**
@@ -164,7 +164,7 @@ public class DefaultConfigurationTest {
     @Test
     public void testConvertValue() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertTrue(100 == (Integer) c.convertValue("aHundred", "100", TypeLiteral.of(Integer.class)));
+        assertThat(100 == (Integer) c.convertValue("aHundred", "100", TypeLiteral.of(Integer.class))).isTrue();
     }
 
     @Test(expected = NullPointerException.class)
@@ -184,13 +184,13 @@ public class DefaultConfigurationTest {
     @Test
     public void with() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertEquals(c.with(config -> config), c);
+        assertThat(c).isEqualTo(c.with(config -> config));
     }
 
     @Test
     public void query() {
         DefaultConfiguration c = new DefaultConfiguration(new MockedConfigurationContext());
-        assertEquals(c.query(config -> "testQ"), "testQ");
+        assertThat("testQ").isEqualTo(c.query(config -> "testQ"));
     }
     
     @Test
@@ -200,16 +200,16 @@ public class DefaultConfigurationTest {
         DefaultConfiguration config2 = new DefaultConfiguration(sharedContext);
         DefaultConfiguration config3 = new DefaultConfiguration(new MockedConfigurationContext());
 
-        assertEquals(config1, config1);
-        assertNotEquals(null, config1);
-        assertNotEquals(sharedContext, config1);
-        assertNotEquals(config1, sharedContext);
-        assertNotEquals("aString", config1);
-        assertEquals(config1, config2);
-        assertNotEquals(config1, config3);
-        assertEquals(config1.hashCode(), config2.hashCode());
-        assertNotEquals(config1.hashCode(), config3.hashCode());
-        assertTrue(config1.toString().contains("Configuration{"));
+        assertThat(config1).isEqualTo(config1);
+        assertThat(config1).isNotEqualTo(null);
+        assertThat(sharedContext).isNotEqualTo(config1);
+        assertThat(config1).isNotEqualTo(sharedContext);
+        assertThat("aString").isNotEqualTo(config1);
+        assertThat(config2).isEqualTo(config1);
+        assertThat(config1).isNotEqualTo(config3);
+        assertThat(config2.hashCode()).isEqualTo(config1.hashCode());
+        assertThat(config1.hashCode()).isNotEqualTo(config3.hashCode());
+        assertThat(config1.toString().contains("Configuration{")).isTrue();
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
@@ -20,12 +20,12 @@ package org.apache.tamaya.spisupport;
 
 import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.spi.ConfigurationProviderSpi;
-import org.junit.Assert;
 import org.junit.Test;
 
 import javax.annotation.Priority;
 import java.util.Collection;
 import java.util.List;
+import static org.assertj.core.api.Assertions.*;
 
 public class DefaultServiceContextTest {
 
@@ -38,8 +38,8 @@ public class DefaultServiceContextTest {
     @Test
     public void testGetService() {
         ConfigurationProviderSpi providerSpi = context.getService(ConfigurationProviderSpi.class);
-        Assert.assertNotNull(providerSpi);
-        Assert.assertTrue(providerSpi instanceof TestConfigurationProvider);
+        assertThat(providerSpi).isNotNull();
+        assertThat(providerSpi instanceof TestConfigurationProvider).isTrue();
     }
 
     @Test(expected = ConfigException.class)
@@ -51,14 +51,14 @@ public class DefaultServiceContextTest {
     public void testGetService_multipleService_shouldReturnServiceWithHighestPriority() {
         MultiImplsInterface service = context.getService(MultiImplsInterface.class);
 
-        Assert.assertNotNull(service);
-        Assert.assertTrue(service instanceof MultiImpl2);
+        assertThat(service).isNotNull();
+        assertThat(service instanceof MultiImpl2).isTrue();
     }
 
     @Test
     public void testGetService_noImpl_shouldReturnEmptyOpional() {
         NoImplInterface service = context.getService(NoImplInterface.class);
-        Assert.assertNull(service);
+        assertThat(service).isNull();
     }
 
 
@@ -66,22 +66,22 @@ public class DefaultServiceContextTest {
     public void testGetServices_shouldReturnServices() {
         {
             Collection<InvalidPriorityInterface> services = context.getServices(InvalidPriorityInterface.class);
-            Assert.assertNotNull(services);
-            Assert.assertEquals(2, services.size());
+            assertThat(services).isNotNull();
+            assertThat(services).hasSize(2);
 
             for (InvalidPriorityInterface service : services) {
-                Assert.assertTrue(service instanceof InvalidPriorityImpl1 || service instanceof InvalidPriorityImpl2);
+                assertThat(service instanceof InvalidPriorityImpl1 || service instanceof InvalidPriorityImpl2).isTrue();
             }
         }
 
         {
             List<MultiImplsInterface> services = context.getServices(MultiImplsInterface.class);
-            Assert.assertNotNull(services);
-            Assert.assertEquals(3, services.size());
+            assertThat(services).isNotNull();
+            assertThat(services).hasSize(3);
 
-            Assert.assertTrue(services.get(0) instanceof MultiImpl2);
-            Assert.assertTrue(services.get(1) instanceof MultiImpl1);
-            Assert.assertTrue(services.get(2) instanceof MultiImpl3);
+            assertThat(services.get(0) instanceof MultiImpl2).isTrue();
+            assertThat(services.get(1) instanceof MultiImpl1).isTrue();
+            assertThat(services.get(2) instanceof MultiImpl3).isTrue();
         }
     }
 
@@ -89,10 +89,10 @@ public class DefaultServiceContextTest {
     public void testGetServices_redundantAccessToServices() {
         for(int i=0;i<10;i++){
             Collection<InvalidPriorityInterface> services = context.getServices(InvalidPriorityInterface.class);
-            Assert.assertNotNull(services);
-            Assert.assertEquals(2, services.size());
+            assertThat(services).isNotNull();
+            assertThat(services).hasSize(2);
             for (InvalidPriorityInterface service : services) {
-                Assert.assertTrue(service instanceof InvalidPriorityImpl1 || service instanceof InvalidPriorityImpl2);
+                assertThat(service instanceof InvalidPriorityImpl1 || service instanceof InvalidPriorityImpl2).isTrue();
             }
         }
     }
@@ -100,8 +100,8 @@ public class DefaultServiceContextTest {
     @Test
     public void testGetServices_noImpl_shouldReturnEmptyList() {
         Collection<NoImplInterface> services = context.getServices(NoImplInterface.class);
-        Assert.assertNotNull(services);
-        Assert.assertTrue(services.isEmpty());
+        assertThat(services).isNotNull();
+        assertThat(services.isEmpty()).isTrue();
     }
 
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
@@ -24,12 +24,8 @@ import org.junit.Test;
 
 import java.math.RoundingMode;
 import java.util.Arrays;
-import java.util.Objects;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test class testing the {@link EnumConverter} class.
@@ -48,13 +44,13 @@ public class EnumConverterTest {
     @Test
     public void testConversionWithMixedCasing() {
         for (String input : Arrays.asList(RoundingMode.CEILING.toString(), "ceiling", "CeiLinG")) {
-            assertEquals(RoundingMode.CEILING, testConverter.convert(input, DUMMY_CONTEXT));
+            assertThat(RoundingMode.CEILING).isEqualTo(testConverter.convert(input, DUMMY_CONTEXT));
         }
     }
 
     @Test
     public void testConvert_OtherValue() {
-        assertNull(testConverter.convert("fooBars", DUMMY_CONTEXT));
+        assertThat(testConverter.convert("fooBars", DUMMY_CONTEXT)).isNull();
     }
 
     @Test
@@ -63,7 +59,7 @@ public class EnumConverterTest {
         EnumConverter<RoundingMode> converter = new EnumConverter<>(RoundingMode.class);
         converter.convert("fooBars", context);
 
-        assertTrue(context.getSupportedFormats().contains("<enumValue> (EnumConverter)"));
+        assertThat(context.getSupportedFormats().contains("<enumValue> (EnumConverter)")).isTrue();
     }
 
     @Test
@@ -72,13 +68,13 @@ public class EnumConverterTest {
         EnumConverter converter2 = new EnumConverter<>(RoundingMode.class);
         EnumConverter converter3 = new EnumConverter<>(TEST_ENUM.class);
 
-        assertEquals(converter1, converter1);
-        assertNotEquals(null, converter1);
-        assertNotEquals(converter1, "aString");
-        assertNotEquals("aString", converter1);
-        assertEquals(converter1, converter2);
-        assertNotEquals(converter1, converter3);
-        assertEquals(converter1.hashCode(), converter2.hashCode());
-        assertNotEquals(converter1.hashCode(), converter3.hashCode());
+        assertThat(converter1).isEqualTo(converter1);
+        assertThat(converter1).isNotEqualTo(null);
+        assertThat(converter1).isNotEqualTo("aString");
+        assertThat("aString").isNotEqualTo(converter1);
+        assertThat(converter2).isEqualTo(converter1);
+        assertThat(converter1).isNotEqualTo(converter3);
+        assertThat(converter2.hashCode()).isEqualTo(converter1.hashCode());
+        assertThat(converter1.hashCode()).isNotEqualTo(converter3.hashCode());
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PriorityServiceComparatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PriorityServiceComparatorTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import javax.annotation.Priority;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsticks on 12.09.16.
@@ -32,10 +32,10 @@ public class PriorityServiceComparatorTest {
 
     @Test
     public void compare() throws Exception {
-        assertTrue(PriorityServiceComparator.getInstance().compare("a", "b")==0);
-        assertTrue(PriorityServiceComparator.getInstance().compare(getClass(), getClass())==0);
-        assertTrue(PriorityServiceComparator.getInstance().compare(new A(), new SystemPropertySource())==-1);
-        assertTrue(PriorityServiceComparator.getInstance().compare(new SystemPropertySource(), new A())==1);
+        assertThat(PriorityServiceComparator.getInstance().compare("a", "b")==0).isTrue();
+        assertThat(PriorityServiceComparator.getInstance().compare(getClass(), getClass())==0).isTrue();
+        assertThat(PriorityServiceComparator.getInstance().compare(new A(), new SystemPropertySource())==-1).isTrue();
+        assertThat(PriorityServiceComparator.getInstance().compare(new SystemPropertySource(), new A())==1).isTrue();
     }
 
     @Priority(100)

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertyConverterManagerTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertyConverterManagerTest.java
@@ -26,12 +26,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.*;
 
 public class PropertyConverterManagerTest {
 
@@ -42,8 +37,8 @@ public class PropertyConverterManagerTest {
     public void customTypeWithFactoryMethodOfIsRecognizedAsSupported() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
 
-        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(MyType.class)),
-                is(true));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(MyType.class)))
+                .isTrue();
     }
 
     @Test
@@ -53,134 +48,134 @@ public class PropertyConverterManagerTest {
         List<PropertyConverter<MyType>> converters = manager.getPropertyConverters(
                 (TypeLiteral) TypeLiteral.of(MyType.class));
 
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<MyType> converter = converters.get(0);
 
         Object result = converter.convert("IN", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(MyType.class));
-        assertThat(((MyType) result).getValue(), equalTo("IN"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(MyType.class);
+        assertThat(((MyType) result).getValue()).isEqualTo("IN");
     }
 
     @Test
     public void testDirectConverterMapping() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(C.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(C.class))).isTrue();
         List<PropertyConverter<C>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(C.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<C> converter = converters.get(0);
         C result = converter.convert("testDirectConverterMapping", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat((result).getInValue(), equalTo("testDirectConverterMapping"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat((result).getInValue()).isEqualTo("testDirectConverterMapping");
     }
 
     @Test
     public void testDirectSuperclassConverterMapping() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(B.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(B.class))).isTrue();
         List<PropertyConverter<B>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(B.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
         converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(B.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<B> converter = converters.get(0);
         B result = converter.convert("testDirectSuperclassConverterMapping", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat(((C) result).getInValue(), equalTo("testDirectSuperclassConverterMapping"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat(((C) result).getInValue()).isEqualTo("testDirectSuperclassConverterMapping");
     }
 
     @Test
     public void testMultipleConverterLoad() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(B.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(B.class))).isTrue();
         List<PropertyConverter<B>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(B.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
         manager = new PropertyConverterManager(true);
         converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(B.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
     }
 
     @Test
     public void testTransitiveSuperclassConverterMapping() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(A.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(A.class))).isTrue();
         List<PropertyConverter<A>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(A.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<A> converter = converters.get(0);
         A result = converter.convert("testTransitiveSuperclassConverterMapping", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat(((C) result).getInValue(), equalTo("testTransitiveSuperclassConverterMapping"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat(((C) result).getInValue()).isEqualTo("testTransitiveSuperclassConverterMapping");
     }
 
     @Test
     public void testDirectInterfaceMapping() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(Readable.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(Readable.class))).isTrue();
         List<PropertyConverter<Readable>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(Readable.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<Readable> converter = converters.get(0);
         Readable result = converter.convert("testDirectInterfaceMapping", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat(((C) result).getInValue(), equalTo("testDirectInterfaceMapping"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat(((C) result).getInValue()).isEqualTo("testDirectInterfaceMapping");
     }
 
     @Test
     public void testTransitiveInterfaceMapping1() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(Runnable.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(Runnable.class))).isTrue();
         List<PropertyConverter<Runnable>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(Runnable.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<Runnable> converter = converters.get(0);
         Runnable result = converter.convert("testTransitiveInterfaceMapping1", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat(((C) result).getInValue(), equalTo("testTransitiveInterfaceMapping1"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat(((C) result).getInValue()).isEqualTo("testTransitiveInterfaceMapping1");
     }
 
     @Test
     public void testTransitiveInterfaceMapping2() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(AutoCloseable.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(AutoCloseable.class))).isTrue();
         List<PropertyConverter<AutoCloseable>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(AutoCloseable.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<AutoCloseable> converter = converters.get(0);
         AutoCloseable result = converter.convert("testTransitiveInterfaceMapping2", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(C.class));
-        assertThat(((C) result).getInValue(), equalTo("testTransitiveInterfaceMapping2"));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(C.class);
+        assertThat(((C) result).getInValue()).isEqualTo("testTransitiveInterfaceMapping2");
     }
 
     @Test
     public void testBoxedConverterMapping() {
         PropertyConverterManager manager = new PropertyConverterManager(true);
-        assertFalse(manager.isTargetTypeSupported(TypeLiteral.of(int.class)));
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(Integer.class)));
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(int.class))).isFalse();
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(Integer.class))).isTrue();
         List<PropertyConverter<Integer>> converters = List.class.cast(manager.getPropertyConverters(TypeLiteral.of(int.class)));
-        assertThat(converters, hasSize(1));
+        assertThat(converters).hasSize(1);
 
         PropertyConverter<Integer> converter = converters.get(0);
         Integer result = converter.convert("101", DUMMY_CONTEXT);
 
-        assertThat(result, notNullValue());
-        assertThat(result, instanceOf(Integer.class));
-        assertThat(result, equalTo(101));
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(Integer.class);
+        assertThat(result).isEqualTo(101);
     }
 
     
@@ -188,8 +183,8 @@ public class PropertyConverterManagerTest {
     public void testCreateEnumPropertyConverter() {
         PropertyConverterManager manager = new PropertyConverterManager(false);
         PropertyConverter pc = manager.createDefaultPropertyConverter(TypeLiteral.of(MyEnum.class));
-        assertTrue(pc instanceof EnumConverter);
-        assertTrue(manager.isTargetTypeSupported(TypeLiteral.of(MyEnum.class)));
+        assertThat(pc instanceof EnumConverter).isTrue();
+        assertThat(manager.isTargetTypeSupported(TypeLiteral.of(MyEnum.class))).isTrue();
     }
 
     @Test
@@ -199,16 +194,16 @@ public class PropertyConverterManagerTest {
         getFactoryMethod.setAccessible(true);
 
         Method foundMethod = (Method) getFactoryMethod.invoke(manager, MyType.class, new String[]{"instanceOf"});
-        assertEquals("instanceOf", foundMethod.getName());
+        assertThat(foundMethod.getName()).isEqualTo("instanceOf");
         
         Method staticOf = (Method) getFactoryMethod.invoke(manager, MyType.class, new String[]{"of"});
-        assertEquals("of", staticOf.getName());
+        assertThat(staticOf.getName()).isEqualTo("of");
 
         Method notFoundMethod = (Method) getFactoryMethod.invoke(manager, MyType.class, new String[]{"missingMethod"});
-        assertNull(notFoundMethod);
+        assertThat(notFoundMethod).isNull();
 
         Method wrongSignature = (Method) getFactoryMethod.invoke(manager, MyType.class, new String[]{"getValue"});
-        assertNull(wrongSignature);
+        assertThat(wrongSignature).isNull();
     }
 
     @Test
@@ -228,10 +223,10 @@ public class PropertyConverterManagerTest {
         method.setAccessible(true);
 
         for (int i = 0; i < boxed.length; i++) {
-            assertEquals(TypeLiteral.of(boxed[i]),
-                    method.invoke(manager, TypeLiteral.of(primitive[i])));
-            assertEquals(TypeLiteral.of(boxed[i].getComponentType()),
-                    method.invoke(manager, TypeLiteral.of(primitive[i].getComponentType())));
+            assertThat(TypeLiteral.of(boxed[i]))
+                    .isEqualTo(method.invoke(manager, TypeLiteral.of(primitive[i])));
+            assertThat(TypeLiteral.of(boxed[i].getComponentType()))
+                    .isEqualTo(method.invoke(manager, TypeLiteral.of(primitive[i].getComponentType())));
         }
     }
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ReflectionUtilTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ReflectionUtilTest.java
@@ -23,7 +23,7 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -43,9 +43,9 @@ public class ReflectionUtilTest<E> {
         Field stringListField = this.getClass().getDeclaredField("reflectable");
         ParameterizedType genericListType = (ParameterizedType) stringListField.getGenericType();
         
-        assertEquals(genericListType.toString(), ReflectionUtil.getParametrizedType(reflectable.getClass()).toString());
-        assertEquals(First.class.getName(), ReflectionUtil.getParametrizedType(multi.getClass()).getRawType().getTypeName());
-        assertNull(ReflectionUtil.getParametrizedType(Object.class));
+        assertThat(ReflectionUtil.getParametrizedType(reflectable.getClass()).toString()).isEqualTo(genericListType.toString());
+        assertThat(ReflectionUtil.getParametrizedType(multi.getClass()).getRawType().getTypeName()).isEqualTo(First.class.getName());
+        assertThat(ReflectionUtil.getParametrizedType(Object.class)).isNull();
     }
     
     private interface First<T> {}

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
@@ -25,7 +25,7 @@ import org.apache.tamaya.spi.PropertyValue;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link RegexPropertyFilter}. Created by anatole on 11.02.16.
@@ -45,32 +45,31 @@ public class RegexPropertyFilterTest {
         map.put(prop1.getKey(), prop1);
         map.put(prop2.getKey(), prop2);
         map.put(prop3.getKey(), prop3);
-        assertEquals(filter.filterProperty(prop1, new FilterContext(prop1, configContext)), prop1);
-        assertNull(filter.filterProperty(prop2, new FilterContext(prop2, configContext)));
-        assertEquals(filter.filterProperty(
+        assertThat(filter.filterProperty(prop1, new FilterContext(prop1, configContext))).isEqualTo(prop1);
+        assertThat(filter.filterProperty(prop2, new FilterContext(prop2, configContext))).isNull();
+        assertThat(filter.filterProperty(
                 prop3,
-                new FilterContext(prop3, map, configContext)), prop3);
-        assertEquals(filter.filterProperty(
+                new FilterContext(prop3, map, configContext))).isEqualTo(prop3);
+        assertThat(filter.filterProperty(
                 prop3,
-                new FilterContext(prop3, map, configContext)), prop3);
+                new FilterContext(prop3, map, configContext))).isEqualTo(prop3);
         filter = new RegexPropertyFilter();
         filter.setIncludes("test1.*");
-        assertNotNull(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext)));
-        assertNull(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext)));
-        assertNotNull(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext)));
+        assertThat(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext))).isNotNull();
+        assertThat(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext))).isNull();
+        assertThat(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext))).isNotNull();
         filter = new RegexPropertyFilter();
         filter.setExcludes("test1.*");
-        assertNull(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext)));
-        assertEquals(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext)),
-                prop2);
-        assertNull(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext)));
+        assertThat(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext))).isNull();
+        assertThat(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext))).isEqualTo(prop2);
+        assertThat(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext))).isNull();
         
         filter = new RegexPropertyFilter();
         filter.setIncludes("test1.*"); //Includes overrides Excludes
         filter.setExcludes("test1.*");
-        assertNotNull(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext)));
-        assertNull(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext)));
-        assertNotNull(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext)));
+        assertThat(filter.filterProperty(prop1, new FilterContext(prop1, map, configContext))).isNotNull();
+        assertThat(filter.filterProperty(prop2, new FilterContext(prop2, map, configContext))).isNull();
+        assertThat(filter.filterProperty(prop3, new FilterContext(prop3, map, configContext))).isNotNull();
         
         
     }
@@ -79,7 +78,7 @@ public class RegexPropertyFilterTest {
     public void testToString() throws Exception {
         RegexPropertyFilter filter = new RegexPropertyFilter();
         filter.setIncludes("test\\..*");
-        assertTrue(filter.toString().contains("test\\..*"));
-        assertTrue(filter.toString().contains("RegexPropertyFilter"));
+        assertThat(filter.toString().contains("test\\..*")).isTrue();
+        assertThat(filter.toString().contains("RegexPropertyFilter")).isTrue();
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
@@ -21,13 +21,11 @@ package org.apache.tamaya.spisupport.propertysource;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValue;
 import org.apache.tamaya.spisupport.PropertySourceComparator;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class BasePropertySourceTest {
 
@@ -73,16 +71,16 @@ public class BasePropertySourceTest {
             }
         };
 
-        Assert.assertEquals(56, PropertySourceComparator.getOrdinal(defaultPropertySource));
-        Assert.assertEquals(1000, new OverriddenOrdinalPropertySource().getOrdinal());
+        assertThat(PropertySourceComparator.getOrdinal(defaultPropertySource)).isEqualTo(56);
+        assertThat(new OverriddenOrdinalPropertySource().getOrdinal()).isEqualTo(1000);
 
         // propertySource with invalid ordinal
-        Assert.assertEquals(1, new OverriddenInvalidOrdinalPropertySource().getOrdinal());
+        assertThat(new OverriddenInvalidOrdinalPropertySource().getOrdinal()).isEqualTo(1);
     }
 
     @Test
     public void testGet() {
-        Assert.assertEquals(1000, new OverriddenOrdinalPropertySource().getOrdinal());
+        assertThat(new OverriddenOrdinalPropertySource().getOrdinal()).isEqualTo(1000);
     }
 
     @Test
@@ -94,14 +92,14 @@ public class BasePropertySourceTest {
         BasePropertySource bs3 = new EmptyPropertySource();
         bs3.setName("testNotEqualsName");
 
-        assertEquals(bs1, bs1);
-        assertNotEquals(null, bs1);
-        assertNotEquals("aString", bs1);
-        assertEquals(bs1, bs2);
-        assertNotEquals(bs1, bs3);
-        assertEquals(bs1.hashCode(), bs2.hashCode());
-        assertNotEquals(bs1.hashCode(), bs3.hashCode());
-        assertTrue(bs1.toStringValues().contains("name='testEqualsName'"));
+        assertThat(bs1).isEqualTo(bs1);
+        assertThat(bs1).isNotEqualTo(null);
+        assertThat("aString").isNotEqualTo(bs1);
+        assertThat(bs2).isEqualTo(bs1);
+        assertThat(bs1).isNotEqualTo(bs3);
+        assertThat(bs2.hashCode()).isEqualTo(bs1.hashCode());
+        assertThat(bs1.hashCode()).isNotEqualTo(bs3.hashCode());
+        assertThat(bs1.toStringValues().contains("name='testEqualsName'")).isTrue();
     }
 
     private class EmptyPropertySource extends BasePropertySource {

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
@@ -22,7 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for PropertySource for reading main arguments as configuration.
@@ -39,47 +39,47 @@ public class CLIPropertySourceTest {
             System.clearProperty("main.args");
             
             CLIPropertySource ps = new CLIPropertySource();
-            assertTrue(ps.getProperties().isEmpty());
+            assertThat(ps.getProperties().isEmpty()).isTrue();
             
             ps = new CLIPropertySource(26);
-            assertTrue(ps.getProperties().isEmpty());
-            assertEquals(26, ps.getOrdinal());
+            assertThat(ps.getProperties().isEmpty()).isTrue();
+            assertThat(ps.getOrdinal()).isEqualTo(26);
             
             ps = new CLIPropertySource("-a", "b");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("a").getValue(), "b");
-            assertTrue(ps.toStringValues().contains("args=[-a, b]"));
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
+            assertThat(ps.toStringValues().contains("args=[-a, b]")).isTrue();
             
             ps = new CLIPropertySource(16, "-c", "d");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("c").getValue(), "d");
-            assertEquals(16, ps.getOrdinal());
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("d").isEqualTo(ps.getProperties().get("c").getValue());
+            assertThat(ps.getOrdinal()).isEqualTo(16);
             
             CLIPropertySource.initMainArgs("-e", "f");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("e").getValue(), "f");
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("f").isEqualTo(ps.getProperties().get("e").getValue());
             
             CLIPropertySource.initMainArgs("--g");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("g").getValue(), "g");
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("g").isEqualTo(ps.getProperties().get("g").getValue());
             
             CLIPropertySource.initMainArgs("sss");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("sss").getValue(), "sss");
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("sss").isEqualTo(ps.getProperties().get("sss").getValue());
             
             CLIPropertySource.initMainArgs("-a", "b", "--c", "sss", "--val=vvv");
-            assertFalse(ps.getProperties().isEmpty());
-            assertEquals(ps.getProperties().get("a").getValue(), "b");
-            assertEquals(ps.getProperties().get("c").getValue(), "c");
-            assertEquals(ps.getProperties().get("sss").getValue(), "sss");
+            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
+            assertThat("c").isEqualTo(ps.getProperties().get("c").getValue());
+            assertThat("sss").isEqualTo(ps.getProperties().get("sss").getValue());
             
             System.setProperty("main.args", "-a b\t--c sss  ");
             ps = new CLIPropertySource();
-            assertFalse(ps.getProperties().isEmpty());
+            assertThat(ps.getProperties().isEmpty()).isFalse();
             System.clearProperty("main.args");
-            assertEquals(ps.getProperties().get("a").getValue(), "b");
-            assertEquals(ps.getProperties().get("c").getValue(), "c");
-            assertEquals(ps.getProperties().get("sss").getValue(), "sss");
+            assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
+            assertThat("c").isEqualTo(ps.getProperties().get("c").getValue());
+            assertThat("sss").isEqualTo(ps.getProperties().get("sss").getValue());
             
         } finally {
             System.getProperties().clear();

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnumConverterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnumConverterTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 
 import java.math.RoundingMode;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test class testing the {@link EnumConverter} class.
@@ -39,22 +38,21 @@ public class EnumConverterTest {
 
     @Test
     public void testConvert() {
-        assertEquals(testConverter.convert(RoundingMode.CEILING.toString(),
-                DUMMY_CONTEXT), RoundingMode.CEILING);
+        assertThat(testConverter.convert(RoundingMode.CEILING.toString(), DUMMY_CONTEXT)).isEqualTo(RoundingMode.CEILING);
     }
 
     @Test
     public void testConvert_LowerCase() {
-        assertEquals(testConverter.convert("ceiling", DUMMY_CONTEXT), RoundingMode.CEILING);
+        assertThat(RoundingMode.CEILING).isEqualTo(testConverter.convert("ceiling", DUMMY_CONTEXT));
     }
 
     @Test
     public void testConvert_MixedCase()  {
-        assertEquals(testConverter.convert("CeiLinG", DUMMY_CONTEXT), RoundingMode.CEILING);
+        assertThat(RoundingMode.CEILING).isEqualTo(testConverter.convert("CeiLinG", DUMMY_CONTEXT));
     }
 
     @Test
     public void testConvert_OtherValue() {
-        assertNull(testConverter.convert("fooBars", DUMMY_CONTEXT));
+        assertThat(testConverter.convert("fooBars", DUMMY_CONTEXT)).isNull();
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 import org.junit.Ignore;
 
 /**
@@ -44,35 +44,35 @@ public class EnvironmentPropertySourceTest {
         String before = stringBufferWriter.toString();
 
         try {
-            assertFalse(envPropertySource.isDisabled());
+            assertThat(envPropertySource.isDisabled()).isFalse();
 
             System.setProperty("tamaya.envprops.prefix", "fakeprefix");
             System.setProperty("tamaya.envprops.disable", "true");
             localEnvironmentPropertySource = new EnvironmentPropertySource();
-            //assertEquals("fakeprefix", environmentSource.getPrefix());
-            assertTrue(localEnvironmentPropertySource.isDisabled());
-            assertNull(localEnvironmentPropertySource.get(System.getenv().entrySet().iterator().next().getKey()));
-            assertTrue(localEnvironmentPropertySource.getName().contains("(disabled)"));
-            assertTrue(localEnvironmentPropertySource.getProperties().isEmpty());
-            assertTrue(localEnvironmentPropertySource.toString().contains("disabled=true"));
+            //assertThat(environmentSource.getPrefix()).isEqualTo("fakeprefix");
+            assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
+            assertThat(localEnvironmentPropertySource.get(System.getenv().entrySet().iterator().next().getKey())).isNull();
+            assertThat(localEnvironmentPropertySource.getName().contains("(disabled)")).isTrue();
+            assertThat(localEnvironmentPropertySource.getProperties().isEmpty()).isTrue();
+            assertThat(localEnvironmentPropertySource.toString().contains("disabled=true")).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "true");
             localEnvironmentPropertySource = new EnvironmentPropertySource();
-            assertTrue(localEnvironmentPropertySource.isDisabled());
+            assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.envprops.disable", "");
             localEnvironmentPropertySource = new EnvironmentPropertySource();
-            assertFalse(localEnvironmentPropertySource.isDisabled());
+            assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "");
             localEnvironmentPropertySource = new EnvironmentPropertySource();
-            assertFalse(localEnvironmentPropertySource.isDisabled());
+            assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
 
         } finally {
             System.getProperties().clear();
@@ -82,24 +82,24 @@ public class EnvironmentPropertySourceTest {
 
     @Test
     public void testGetOrdinal() throws Exception {
-        assertEquals(EnvironmentPropertySource.DEFAULT_ORDINAL, envPropertySource.getOrdinal());
+        assertThat(envPropertySource.getOrdinal()).isEqualTo(EnvironmentPropertySource.DEFAULT_ORDINAL);
         EnvironmentPropertySource constructorSetOrdinal22 = new EnvironmentPropertySource(22);
-        assertEquals(22, constructorSetOrdinal22.getOrdinal());
+        assertThat(constructorSetOrdinal22.getOrdinal()).isEqualTo(22);
 
         EnvironmentPropertySource constructorSetOrdinal16 = new EnvironmentPropertySource("sixteenprefix", 16);
-        assertEquals(16, constructorSetOrdinal16.getOrdinal());
+        assertThat(constructorSetOrdinal16.getOrdinal()).isEqualTo(16);
 
     }
 
     @Test
     public void testGetName() throws Exception {
-        assertEquals("environment-properties", envPropertySource.getName());
+        assertThat(envPropertySource.getName()).isEqualTo("environment-properties");
     }
 
     @Test
     public void testGet() throws Exception {
         for (Map.Entry<String, String> envEntry : System.getenv().entrySet()) {
-            assertEquals(envPropertySource.get(envEntry.getKey()).getValue(), envEntry.getValue());
+            assertThat(envEntry.getValue()).isEqualTo(envPropertySource.get(envEntry.getKey()).getValue());
         }
     }
     
@@ -108,7 +108,7 @@ public class EnvironmentPropertySourceTest {
     public void testPrefixedGet() throws Exception {
         EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("fancyprefix");
         localEnvironmentPropertySource.setPropertiesProvider(new MockedSystemPropertiesProvider());
-        assertEquals("fancyprefix.somekey.value", localEnvironmentPropertySource.get("somekey").getValue());
+        assertThat(localEnvironmentPropertySource.get("somekey").getValue()).isEqualTo("fancyprefix.somekey.value");
     }
 
     @Test
@@ -116,7 +116,7 @@ public class EnvironmentPropertySourceTest {
         Map<String, PropertyValue> props = envPropertySource.getProperties();
         for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
             if (!en.getKey().startsWith("_")) {
-                assertEquals(System.getenv(en.getKey()), en.getValue().getValue());
+                assertThat(en.getValue().getValue()).isEqualTo(System.getenv(en.getKey()));
             }
         }
     }
@@ -126,17 +126,17 @@ public class EnvironmentPropertySourceTest {
         EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("someprefix");
         Map<String, PropertyValue> props = localEnvironmentPropertySource.getProperties();
         for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
-            assertTrue(en.getKey().startsWith("someprefix"));
+            assertThat(en.getKey().startsWith("someprefix")).isTrue();
             String thisKey = en.getKey().replaceFirst("someprefix", "");
             if (!thisKey.startsWith("_")) {
-                assertEquals(System.getenv(thisKey), en.getValue().getValue());
+                assertThat(en.getValue().getValue()).isEqualTo(System.getenv(thisKey));
             }
         }
     }
 
     @Test
     public void testIsScannable() throws Exception {
-        assertTrue(envPropertySource.isScannable());
+        assertThat(envPropertySource.isScannable()).isTrue();
     }
     
     private class MockedSystemPropertiesProvider extends EnvironmentPropertySource.SystemPropertiesProvider {

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
@@ -22,13 +22,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import org.apache.tamaya.spi.PropertySource;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
+
 
 public class JavaConfigurationProviderTest {
 
@@ -38,13 +35,13 @@ public class JavaConfigurationProviderTest {
     @Test
     public void loadsSimpleAndXMLPropertyFilesProper() {
         PropertySource propertySource = new JavaConfigurationPropertySource();
-        MatcherAssert.assertThat(propertySource.getProperties().keySet(), Matchers.hasSize(7));  // double the size for .source values.
+        assertThat(propertySource.getProperties().keySet()).hasSize(7);  // double the size for .source values.
 
         for (int i = 1; i < 6; i++) {
             String key = "confkey" + i;
             String value = "javaconf-value" + i;
 
-            MatcherAssert.assertThat(value, Matchers.equalTo(propertySource.get(key).getValue()));
+            assertThat(value).isEqualTo(propertySource.get(key).getValue());
         }
 
     }
@@ -57,31 +54,31 @@ public class JavaConfigurationProviderTest {
         String before = stringBufferWriter.toString();
 
         try {
-            assertTrue(localJavaConfigurationPropertySource.isEnabled());
+            assertThat(localJavaConfigurationPropertySource.isEnabled()).isTrue();
 
             System.setProperty("tamaya.defaultprops.disable", "true");
             localJavaConfigurationPropertySource = new JavaConfigurationPropertySource();
-            assertFalse(localJavaConfigurationPropertySource.isEnabled());
-            assertTrue(localJavaConfigurationPropertySource.getProperties().isEmpty());
-            assertTrue(localJavaConfigurationPropertySource.toString().contains("enabled=false"));
+            assertThat(localJavaConfigurationPropertySource.isEnabled()).isFalse();
+            assertThat(localJavaConfigurationPropertySource.getProperties().isEmpty()).isTrue();
+            assertThat(localJavaConfigurationPropertySource.toString().contains("enabled=false")).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "true");
             localJavaConfigurationPropertySource = new JavaConfigurationPropertySource();
-            assertFalse(localJavaConfigurationPropertySource.isEnabled());
+            assertThat(localJavaConfigurationPropertySource.isEnabled()).isFalse();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaultprops.disable", "");
             localJavaConfigurationPropertySource = new JavaConfigurationPropertySource();
-            assertTrue(localJavaConfigurationPropertySource.isEnabled());
+            assertThat(localJavaConfigurationPropertySource.isEnabled()).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "");
             localJavaConfigurationPropertySource = new JavaConfigurationPropertySource();
-            assertTrue(localJavaConfigurationPropertySource.isEnabled());
+            assertThat(localJavaConfigurationPropertySource.isEnabled()).isTrue();
 
         } finally {
             System.getProperties().clear();

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tamaya.spisupport.propertysource;
 
-import org.apache.tamaya.spisupport.propertysource.SimplePropertySource;
 import org.apache.tamaya.spi.PropertySource;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class PropertiesFilePropertySourceTest {
 
@@ -33,28 +33,28 @@ public class PropertiesFilePropertySourceTest {
 
     @Test
     public void testGetOrdinal() {
-        Assert.assertEquals(0, testfilePropertySource.getOrdinal());
-        Assert.assertEquals(Integer.parseInt(overrideOrdinalPropertySource.get(PropertySource.TAMAYA_ORDINAL)
-                .getValue()),
-                overrideOrdinalPropertySource.getOrdinal());
+        assertThat(testfilePropertySource.getOrdinal()).isEqualTo(0);
+        assertThat(Integer.parseInt(overrideOrdinalPropertySource.get(PropertySource.TAMAYA_ORDINAL)
+                .getValue()))
+                .isEqualTo(overrideOrdinalPropertySource.getOrdinal());
     }
 
 
     @Test
     public void testGet() {
-        Assert.assertEquals("val3", testfilePropertySource.get("key3").getValue());
-        Assert.assertEquals("myval5", overrideOrdinalPropertySource.get("mykey5").getValue());
-        Assert.assertNull(testfilePropertySource.get("nonpresentkey"));
+        assertThat(testfilePropertySource.get("key3").getValue()).isEqualTo("val3");
+        assertThat(overrideOrdinalPropertySource.get("mykey5").getValue()).isEqualTo("myval5");
+        assertThat(testfilePropertySource.get("nonpresentkey")).isNull();
     }
 
 
     @Test
     public void testGetProperties() throws Exception {
-        Assert.assertEquals(5, testfilePropertySource.getProperties().size());
-        Assert.assertTrue(testfilePropertySource.getProperties().containsKey("key1"));
-        Assert.assertTrue(testfilePropertySource.getProperties().containsKey("key2"));
-        Assert.assertTrue(testfilePropertySource.getProperties().containsKey("key3"));
-        Assert.assertTrue(testfilePropertySource.getProperties().containsKey("key4"));
-        Assert.assertTrue(testfilePropertySource.getProperties().containsKey("key5"));
+        assertThat(testfilePropertySource.getProperties()).hasSize(5);
+        assertThat(testfilePropertySource.getProperties().containsKey("key1")).isTrue();
+        assertThat(testfilePropertySource.getProperties().containsKey("key2")).isTrue();
+        assertThat(testfilePropertySource.getProperties().containsKey("key3")).isTrue();
+        assertThat(testfilePropertySource.getProperties().containsKey("key4")).isTrue();
+        assertThat(testfilePropertySource.getProperties().containsKey("key5")).isTrue();
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya.spisupport.propertysource;
 
 import java.net.URL;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
  	
 
 /**
@@ -35,17 +35,17 @@ public class PropertiesResourcePropertySourceTest {
     @Test
     public void testBasicConstructor() {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(resource);
-        assertNotNull(source);
-        assertTrue(5 == source.getProperties().size()); // double the size for .source values.
-        assertTrue(source.getProperties().containsKey("key1"));
+        assertThat(source).isNotNull();
+        assertThat(5 == source.getProperties().size()).isTrue(); // double the size for .source values.
+        assertThat(source.getProperties().containsKey("key1")).isTrue();
     }
 
     @Test
     public void testPrefixedConstructor() {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(resource, "somePrefix");
-        assertNotNull(source);
-        assertTrue(5 == source.getProperties().size());
-        assertTrue(source.getProperties().containsKey("somePrefixkey1"));
+        assertThat(source).isNotNull();
+        assertThat(5 == source.getProperties().size()).isTrue();
+        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
     }
 
     @Test
@@ -53,9 +53,9 @@ public class PropertiesResourcePropertySourceTest {
         //File path must be relative to classloader, not the class
         System.out.println(resource.getPath());
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix");
-        assertNotNull(source);
-        assertTrue(5 == source.getProperties().size());
-        assertTrue(source.getProperties().containsKey("somePrefixkey1"));
+        assertThat(source).isNotNull();
+        assertThat(5 == source.getProperties().size()).isTrue();
+        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
     }
     
     @Test
@@ -67,16 +67,16 @@ public class PropertiesResourcePropertySourceTest {
             }
         };
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix", badLoader);
-        assertNotNull(source);
-        assertTrue(source.getProperties().isEmpty());
+        assertThat(source).isNotNull();
+        assertThat(source.getProperties().isEmpty()).isTrue();
     }
     
     @Test
     public void testPrefixedPathClassloaderConstructor() {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix", null);
-        assertNotNull(source);
-        assertTrue(5 == source.getProperties().size());
-        assertTrue(source.getProperties().containsKey("somePrefixkey1"));
+        assertThat(source).isNotNull();
+        assertThat(5 == source.getProperties().size()).isTrue();
+        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
@@ -28,17 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 
 public class SimplePropertySourceTest {
 
@@ -48,10 +38,10 @@ public class SimplePropertySourceTest {
 
         SimplePropertySource source = new SimplePropertySource(resource);
 
-        assertThat(source, notNullValue());
-        assertThat(source.getProperties(), aMapWithSize(2)); // double the size for .source values.
-        assertThat(source.getProperties(), hasEntry("a", PropertyValue.of("a", "b", resource.toString())));
-        assertThat(source.getProperties(), hasEntry("b", PropertyValue.of("b", "1", resource.toString())));
+        assertThat(source).isNotNull();
+        assertThat(source.getProperties()).hasSize(2); // double the size for .source values.
+        assertThat(source.getProperties()).contains(entry("a", PropertyValue.of("a", "b", resource.toString())));
+        assertThat(source.getProperties()).contains(entry("b", PropertyValue.of("b", "1", resource.toString())));
 
     }
 
@@ -66,8 +56,9 @@ public class SimplePropertySourceTest {
             catchedException = ce;
         }
 
-        assertThat(catchedException.getMessage(), allOf(startsWith("Error loading properties from"),
-                endsWith("non-xml-properties.xml")));
+        assertThat(catchedException.getMessage())
+                .startsWith("Error loading properties from")
+                .endsWith("non-xml-properties.xml");
     }
 
     @Test
@@ -81,8 +72,9 @@ public class SimplePropertySourceTest {
             catchedException = ce;
         }
 
-        assertThat(catchedException.getMessage(), allOf(startsWith("Error loading properties from"),
-                endsWith("invalid-properties.xml")));
+        assertThat(catchedException.getMessage())
+                .startsWith("Error loading properties from")
+                .endsWith("invalid-properties.xml");
     }
 
     @Test
@@ -91,8 +83,8 @@ public class SimplePropertySourceTest {
 
         SimplePropertySource source = new SimplePropertySource(resource);
 
-        assertThat(source, notNullValue());
-        assertThat(source.getProperties(), aMapWithSize(5)); // double the size for .source values.
+        assertThat(source).isNotNull();
+        assertThat(source.getProperties()).hasSize(5); // double the size for .source values.
     }
 
     @Test
@@ -101,16 +93,16 @@ public class SimplePropertySourceTest {
         propertyFirst.put("firstKey", "firstValue");
 
         SimplePropertySource source = new SimplePropertySource("testWithMap", propertyFirst, 166);
-        assertEquals("testWithMap", source.getName());
-        assertEquals(166, source.getDefaultOrdinal());
-        assertTrue(source.getProperties().containsKey("firstKey"));
+        assertThat(source.getName()).isEqualTo("testWithMap");
+        assertThat(source.getDefaultOrdinal()).isEqualTo(166);
+        assertThat(source.getProperties().containsKey("firstKey")).isTrue();
 
     }
 
     @Test
     public void builder() throws Exception {
-        assertNotNull(SimplePropertySource.newBuilder());
-        assertNotEquals(SimplePropertySource.newBuilder(), SimplePropertySource.newBuilder());
+        assertThat(SimplePropertySource.newBuilder()).isNotNull();
+        assertThat(SimplePropertySource.newBuilder()).isNotEqualTo(SimplePropertySource.newBuilder());
     }
 
     @Test
@@ -121,8 +113,8 @@ public class SimplePropertySourceTest {
                 .withDefaultOrdinal(166)
                 .build();
 
-        assertEquals(55, ps1.getOrdinal());
-        assertEquals(166, ps1.getDefaultOrdinal());
+        assertThat(ps1.getOrdinal()).isEqualTo(55);
+        assertThat(ps1.getDefaultOrdinal()).isEqualTo(166);
     }
 
     @Test
@@ -130,10 +122,10 @@ public class SimplePropertySourceTest {
         //SimplePropertySource ps1 = SimplePropertySource.newBuilder()
         //        .withName("test1")
         //        .build();
-        //assertEquals("test1", ps1.getName());
+        //assertThat(ps1.getName()).isEqualTo("test1");
         SimplePropertySource ps1 = SimplePropertySource.newBuilder()
                 .withUuidName().build();
-        assertNotNull(UUID.fromString(ps1.getName()));
+        assertThat(UUID.fromString(ps1.getName())).isNotNull();
     }
 
     @Test
@@ -141,7 +133,7 @@ public class SimplePropertySourceTest {
         SimplePropertySource ps1 = SimplePropertySource.newBuilder()
                 .withUuidName()
                 .withProperty("a", "b").build();
-        assertEquals("b", ps1.get("a").getValue());
+        assertThat(ps1.get("a").getValue()).isEqualTo("b");
     }
 
     @Test
@@ -150,15 +142,15 @@ public class SimplePropertySourceTest {
                 .withUuidName()
                 .withProperty("a", "b")
                 .build();
-        assertNotNull(ps1.getProperties());
-        assertEquals(1, ps1.getProperties().size());
-        assertEquals("b", ps1.getProperties().get("a").getValue());
+        assertThat(ps1.getProperties()).isNotNull();
+        assertThat(ps1.getProperties()).hasSize(1);
+        assertThat(ps1.getProperties().get("a").getValue()).isEqualTo("b");
     }
 
     @Test
     public void testScannable() {
         SimplePropertySource sps = SimplePropertySource.newBuilder().withUuidName().build();
-        assertTrue(sps.isScannable());
+        assertThat(sps.isScannable()).isTrue();
     }
 
     @Test
@@ -175,9 +167,9 @@ public class SimplePropertySourceTest {
                 .withProperties(resource)
                 .build();
 
-        assertEquals("firstValue", sps.get("firstKey").getValue());
-        assertThat(sps.getProperties(), hasEntry("a", PropertyValue.of("a", "b", resource.toString())));
-        assertThat(sps.getProperties(), hasEntry("b", PropertyValue.of("b", "1", resource.toString())));
+        assertThat(sps.get("firstKey").getValue()).isEqualTo("firstValue");
+        assertThat(sps.getProperties()).contains(entry("a", PropertyValue.of("a", "b", resource.toString())));
+        assertThat(sps.getProperties()).contains(entry("b", PropertyValue.of("b", "1", resource.toString())));
 
         sps = SimplePropertySource.newBuilder()
                 .withUuidName()
@@ -185,8 +177,8 @@ public class SimplePropertySourceTest {
                 .withProperties(resourceAsFile)
                 .build();
 
-        assertEquals("firstValue", sps.get("firstKey").getValue());
-        assertThat(sps.getProperties(), hasEntry("a", PropertyValue.of("a", "b", resource.toString())));
-        assertThat(sps.getProperties(), hasEntry("b", PropertyValue.of("b", "1", resource.toString())));
+        assertThat(sps.get("firstKey").getValue()).isEqualTo("firstValue");
+        assertThat(sps.getProperties()).contains(entry("a", PropertyValue.of("a", "b", resource.toString())));
+        assertThat(sps.getProperties()).contains(entry("b", PropertyValue.of("b", "1", resource.toString())));
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySourceTest.java
@@ -23,15 +23,11 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValue;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Map;
 import java.util.Properties;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SystemPropertySourceTest {
 
@@ -45,35 +41,35 @@ public class SystemPropertySourceTest {
         String before = stringBufferWriter.toString();
 
         try {
-            assertFalse(testPropertySource.toStringValues().contains("disabled=true"));
+            assertThat(testPropertySource.toStringValues().contains("disabled=true")).isFalse();
 
             System.setProperty("tamaya.sysprops.prefix", "fakeprefix");
             System.setProperty("tamaya.sysprops.disable", "true");
             localSystemPropertySource = new SystemPropertySource();
-            //assertEquals("fakeprefix", localSystemPropertySource.getPrefix());
-            assertTrue(localSystemPropertySource.toStringValues().contains("disabled=true"));
-            assertNull(localSystemPropertySource.get(System.getenv().entrySet().iterator().next().getKey()));
-            assertTrue(localSystemPropertySource.getName().contains("(disabled)"));
-            assertTrue(localSystemPropertySource.getProperties().isEmpty());
-            assertTrue(localSystemPropertySource.toString().contains("disabled=true"));
+            //assertThat(localSystemPropertySource.getPrefix()).isEqualTo("fakeprefix");
+            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isTrue();
+            assertThat(localSystemPropertySource.get(System.getenv().entrySet().iterator().next().getKey())).isNull();
+            assertThat(localSystemPropertySource.getName().contains("(disabled)")).isTrue();
+            assertThat(localSystemPropertySource.getProperties().isEmpty()).isTrue();
+            assertThat(localSystemPropertySource.toString().contains("disabled=true")).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "true");
             localSystemPropertySource = new SystemPropertySource();
-            assertTrue(localSystemPropertySource.toStringValues().contains("disabled=true"));
+            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isTrue();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.sysprops.disable", "");
             localSystemPropertySource = new SystemPropertySource();
-            assertFalse(localSystemPropertySource.toStringValues().contains("disabled=true"));
+            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isFalse();
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "");
             localSystemPropertySource = new SystemPropertySource();
-            assertFalse(localSystemPropertySource.toStringValues().contains("disabled=true"));
+            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isFalse();
 
         } finally {
             System.getProperties().clear();
@@ -85,31 +81,31 @@ public class SystemPropertySourceTest {
     public void testGetOrdinal() throws Exception {
 
         // test the default ordinal
-        Assert.assertEquals(SystemPropertySource.DEFAULT_ORDINAL, testPropertySource.getOrdinal());
+        assertThat(testPropertySource.getOrdinal()).isEqualTo(SystemPropertySource.DEFAULT_ORDINAL);
 
         // set the ordinal to 1001
         System.setProperty(PropertySource.TAMAYA_ORDINAL, "1001");
-        Assert.assertEquals(1001, new SystemPropertySource().getOrdinal());
+        assertThat(new SystemPropertySource().getOrdinal()).isEqualTo(1001);
         // currently its not possible to change ordinal at runtime
 
         // reset it to not destroy other tests!!
         System.clearProperty(PropertySource.TAMAYA_ORDINAL);
 
         SystemPropertySource constructorSetOrdinal22 = new SystemPropertySource(22);
-        assertEquals(22, constructorSetOrdinal22.getOrdinal());
+        assertThat(constructorSetOrdinal22.getOrdinal()).isEqualTo(22);
 
         SystemPropertySource constructorSetOrdinal16 = new SystemPropertySource("sixteenprefix", 16);
-        assertEquals(16, constructorSetOrdinal16.getOrdinal());
+        assertThat(constructorSetOrdinal16.getOrdinal()).isEqualTo(16);
     }
 
     @Test
     public void testIsScannable() throws Exception {
-        assertTrue(testPropertySource.isScannable());
+        assertThat(testPropertySource.isScannable()).isTrue();
     }
 
     @Test
     public void testGetName() throws Exception {
-        Assert.assertEquals("system-properties", testPropertySource.getName());
+        assertThat(testPropertySource.getName()).isEqualTo("system-properties");
     }
 
     @Test
@@ -117,9 +113,8 @@ public class SystemPropertySourceTest {
         String propertyKeyToCheck = System.getProperties().stringPropertyNames().iterator().next();
 
         PropertyValue property = testPropertySource.get(propertyKeyToCheck);
-        Assert.assertNotNull("Property '" + propertyKeyToCheck + "' is not present in "
-                + SystemPropertySource.class.getSimpleName(), property);
-        Assert.assertEquals(System.getProperty(propertyKeyToCheck), property.getValue());
+        assertThat(property).isNotNull();
+        assertThat(property.getValue()).isEqualTo(System.getProperty(propertyKeyToCheck));
     }
 
     @Test
@@ -143,10 +138,8 @@ public class SystemPropertySourceTest {
                 continue; // meta entry
             }
             num++;
-            Assert.assertEquals("Entry values for key '" + propertySourceEntry.getKey() + "' do not match",
-                    systemEntries.getProperty(propertySourceEntry.getKey()), propertySourceEntry.getValue());
+            assertThat(systemEntries.getProperty(propertySourceEntry.getKey())).isEqualTo(propertySourceEntry.getValue());
         }
-        Assert.assertEquals("size of System.getProperties().entrySet() must be the same as SystemPropertySrouce.getProperties().entrySet()",
-                systemEntries.size(), num);
+          assertThat(systemEntries).hasSize(num);
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  *
@@ -37,9 +37,9 @@ public class WrappedPropertySourceTest {
     @Test
     public void testOf_PropertySource() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource());
-        assertEquals("MockedWrappablePropertySource", instance.getName());
+        assertThat(instance.getName()).isEqualTo("MockedWrappablePropertySource");
         WrappedPropertySource instance2 = WrappedPropertySource.of(instance);
-        assertEquals("MockedWrappablePropertySource", instance2.getName());
+        assertThat(instance2.getName()).isEqualTo("MockedWrappablePropertySource");
     }
 
     /**
@@ -48,12 +48,12 @@ public class WrappedPropertySourceTest {
     @Test
     public void testOrdinalsAndOrdinalConstructors() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource(), null);
-        assertEquals(10, instance.getOrdinal());
+        assertThat(instance.getOrdinal()).isEqualTo(10);
         instance.setOrdinal(20);
-        assertEquals(20, instance.getOrdinal());
+        assertThat(instance.getOrdinal()).isEqualTo(20);
         
         WrappedPropertySource instance2 = WrappedPropertySource.of(instance, null);
-        assertEquals(10, instance2.getOrdinal());
+        assertThat(instance2.getOrdinal()).isEqualTo(10);
     }
 
     /**
@@ -67,9 +67,9 @@ public class WrappedPropertySourceTest {
         first.setName("second");
         
         WrappedPropertySource instance = WrappedPropertySource.of(first);
-        assertEquals(first, instance.getDelegate());
+        assertThat(instance.getDelegate()).isEqualTo(first);
         instance.setDelegate(second);
-        assertEquals(second, instance.getDelegate());
+        assertThat(instance.getDelegate()).isEqualTo(second);
         
     }
 
@@ -81,7 +81,7 @@ public class WrappedPropertySourceTest {
     public void testGet() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource());
         PropertyValue result = instance.get("thisKey");
-        assertEquals("valueFromMockedWrappablePropertySource", result.getValue());
+        assertThat(result.getValue()).isEqualTo("valueFromMockedWrappablePropertySource");
     }
 
     /**
@@ -91,8 +91,8 @@ public class WrappedPropertySourceTest {
     public void testGetProperties() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource());
         Map<String, PropertyValue> result = instance.getProperties();
-        assertTrue(result.containsKey("someKey"));
-        assertEquals(1, result.size());
+        assertThat(result.containsKey("someKey")).isTrue();
+        assertThat(result).hasSize(1);
     }
 
     /**
@@ -101,7 +101,7 @@ public class WrappedPropertySourceTest {
     @Test
     public void testIsScannable() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource());
-        assertTrue(instance.isScannable());
+        assertThat(instance.isScannable()).isTrue();
     }
 
     @Test
@@ -117,16 +117,16 @@ public class WrappedPropertySourceTest {
         WrappedPropertySource wps2 = WrappedPropertySource.of(source2);
         WrappedPropertySource wps3 = WrappedPropertySource.of(source3);
 
-        assertEquals(wps1, wps1);
-        assertNotEquals(null, wps1);
-        assertNotEquals(source1, wps1);
-        assertNotEquals(wps1, source1);
-        assertNotEquals("aString", wps1);
-        assertEquals(wps1, wps2);
-        assertNotEquals(wps1, wps3);
-        assertEquals(wps1.hashCode(), wps2.hashCode());
-        assertNotEquals(wps1.hashCode(), wps3.hashCode());
-        assertTrue(wps1.toString().contains("name=testEqualsName"));
+        assertThat(wps1).isEqualTo(wps1);
+        assertThat(wps1).isNotEqualTo(null);
+        assertThat(source1).isNotEqualTo(wps1);
+        assertThat(wps1).isNotEqualTo(source1);
+        assertThat("aString").isNotEqualTo(wps1);
+        assertThat(wps2).isEqualTo(wps1);
+        assertThat(wps1).isNotEqualTo(wps3);
+        assertThat(wps2.hashCode()).isEqualTo(wps1.hashCode());
+        assertThat(wps1.hashCode()).isNotEqualTo(wps3.hashCode());
+        assertThat(wps1.toString().contains("name=testEqualsName")).isTrue();
     }
 
     private class MockedWrappablePropertySource implements PropertySource{

--- a/examples/01-minimal/pom.xml
+++ b/examples/01-minimal/pom.xml
@@ -49,10 +49,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/examples/02-custom-property-source/pom.xml
+++ b/examples/02-custom-property-source/pom.xml
@@ -46,10 +46,6 @@ under the License.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/examples/11-distributed/pom.xml
+++ b/examples/11-distributed/pom.xml
@@ -82,10 +82,6 @@
             <version>${tamaya.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/examples/11-distributed/src/test/java/org/apache/tamaya/examples/distributed/DisplayContentTest.java
+++ b/examples/11-distributed/src/test/java/org/apache/tamaya/examples/distributed/DisplayContentTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.examples.distributed;
 
 import io.vertx.core.json.Json;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsticks on 13.11.16.
@@ -41,8 +41,8 @@ public class DisplayContentTest {
         content.content.put("content", "myContent");
         String val = Json.encode(content);
         DisplayContent decoded = Json.decodeValue(val, DisplayContent.class);
-        assertNotNull(decoded);
-        assertEquals(content, decoded);
+        assertThat(decoded).isNotNull();
+        assertThat(decoded).isEqualTo(content);
     }
 
 }

--- a/examples/11-distributed/src/test/java/org/apache/tamaya/examples/distributed/DisplayRegistrationTest.java
+++ b/examples/11-distributed/src/test/java/org/apache/tamaya/examples/distributed/DisplayRegistrationTest.java
@@ -22,7 +22,7 @@ package org.apache.tamaya.examples.distributed;
 import io.vertx.core.json.Json;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Created by atsticks on 13.11.16.
@@ -63,8 +63,8 @@ public class DisplayRegistrationTest {
         DisplayRegistration reg = new DisplayRegistration("myDisplay", "VT100");
         String val = Json.encode(reg);
         DisplayRegistration decoded = Json.decodeValue(val, DisplayRegistration.class);
-        assertNotNull(decoded);
-        assertEquals(reg, decoded);
+        assertThat(decoded).isNotNull();
+        assertThat(decoded).isEqualTo(reg);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <enforcer.version>1.4.1</enforcer.version>
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
-        <hamcrest.version>2.0.0.0</hamcrest.version>
         <javadoc.version>3.0.0</javadoc.version>
         <!-- Must/should match the JRuby version used by AsciidoctorJ -->
         <jruby.version>1.7.26</jruby.version>
@@ -220,12 +219,6 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -237,18 +230,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>java-hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
             <!-- quality gates -->


### PR DESCRIPTION
This seemingly-lengthy commit converts all of the assertions in tests
from a combination of JUnit, Hamcrest, and AssertJ to only AssertJ.
None of the logic has changed, only the syntax.

It then drops Hamcrest from the pom files.  Please let me know if I
missed anything.