### PR TITLE
TAMAYA-333: null checks for ::equals(Object) methods

### DIFF
--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BigDecimalConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BigDecimalConverter.java
@@ -66,7 +66,7 @@ public class BigDecimalConverter implements PropertyConverter<BigDecimal>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BigIntegerConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BigIntegerConverter.java
@@ -95,7 +95,7 @@ public class BigIntegerConverter implements PropertyConverter<BigInteger>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BooleanConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/BooleanConverter.java
@@ -63,7 +63,7 @@ public class BooleanConverter implements PropertyConverter<Boolean> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ByteConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ByteConverter.java
@@ -73,7 +73,7 @@ public class ByteConverter implements PropertyConverter<Byte>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CharConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CharConverter.java
@@ -73,7 +73,7 @@ public class CharConverter implements PropertyConverter<Character>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ClassConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ClassConverter.java
@@ -68,7 +68,7 @@ public class ClassConverter implements PropertyConverter<Class<?>>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CurrencyConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/CurrencyConverter.java
@@ -92,7 +92,7 @@ public class CurrencyConverter implements PropertyConverter<Currency> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/DoubleConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/DoubleConverter.java
@@ -83,7 +83,7 @@ public class DoubleConverter implements PropertyConverter<Double> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/DurationConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/DurationConverter.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Component;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -49,7 +50,7 @@ public class DurationConverter implements PropertyConverter<Duration> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/FileConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/FileConverter.java
@@ -52,7 +52,7 @@ public class FileConverter implements PropertyConverter<File> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/FloatConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/FloatConverter.java
@@ -83,7 +83,7 @@ public class FloatConverter implements PropertyConverter<Float> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/InstantConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/InstantConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class InstantConverter implements PropertyConverter<Instant> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/IntegerConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/IntegerConverter.java
@@ -76,7 +76,7 @@ public class IntegerConverter implements PropertyConverter<Integer>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalDateConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalDateConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class LocalDateConverter implements PropertyConverter<LocalDate> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class LocalDateTimeConverter implements PropertyConverter<LocalDateTime> 
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalTimeConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LocalTimeConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.LocalTime;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class LocalTimeConverter implements PropertyConverter<LocalTime> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LongConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LongConverter.java
@@ -73,7 +73,7 @@ public class LongConverter implements PropertyConverter<Long>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/NumberConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/NumberConverter.java
@@ -74,7 +74,7 @@ public class NumberConverter implements PropertyConverter<Number>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class OffsetDateTimeConverter implements PropertyConverter<OffsetDateTime
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverter.java
@@ -23,6 +23,7 @@ import org.apache.tamaya.spi.PropertyConverter;
 import org.osgi.service.component.annotations.Component;
 
 import java.time.OffsetTime;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +48,7 @@ public class OffsetTimeConverter implements PropertyConverter<OffsetTime> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OptionalConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/OptionalConverter.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -54,7 +55,7 @@ public class OptionalConverter implements PropertyConverter<Optional> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/PathConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/PathConverter.java
@@ -53,7 +53,7 @@ public class PathConverter implements PropertyConverter<Path> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ShortConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ShortConverter.java
@@ -73,7 +73,7 @@ public class ShortConverter implements PropertyConverter<Short>{
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/SupplierConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/SupplierConverter.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
@@ -60,7 +61,7 @@ public class SupplierConverter implements PropertyConverter<Supplier> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/URIConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/URIConverter.java
@@ -52,7 +52,7 @@ public class URIConverter implements PropertyConverter<URI> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/URLConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/URLConverter.java
@@ -52,7 +52,7 @@ public class URLConverter implements PropertyConverter<URL> {
 
     @Override
     public boolean equals(Object o){
-        return getClass().equals(o.getClass());
+        return Objects.nonNull(o) && getClass().equals(o.getClass());
     }
 
     @Override

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
@@ -135,4 +135,13 @@ public class BigDecimalConverterTest {
 		assertThat(value).isNull();
 		verify(context).addSupportedFormats(BigDecimalConverter.class, "<bigDecimal> -> new BigDecimal(String)");
 	}
+
+    @Test
+    public void testEquality() throws Exception {
+        BigDecimalConverter converter = new BigDecimalConverter();
+
+        assertThat(converter).isEqualTo(new BigDecimalConverter());
+        assertThat(converter).isNotEqualTo(new BigIntegerConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
@@ -157,4 +157,13 @@ public class BigIntegerConverterTest {
         assertThat(instance.hashCode()).isEqualTo(BigIntegerConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        BigIntegerConverter converter = new BigIntegerConverter();
+
+        assertThat(converter).isEqualTo(new BigIntegerConverter());
+        assertThat(converter).isNotEqualTo(new BooleanConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
+
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
@@ -147,4 +147,12 @@ public class BooleanConverterTest {
         assertThat(instance.hashCode()).isEqualTo(BooleanConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        BooleanConverter converter = new BooleanConverter();
+
+        assertThat(converter).isEqualTo(new BooleanConverter());
+        assertThat(converter).isNotEqualTo(new ByteConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
@@ -110,4 +110,13 @@ public class ByteConverterTest {
         ByteConverter instance = new ByteConverter();
         assertThat(instance.hashCode()).isEqualTo(ByteConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        ByteConverter converter = new ByteConverter();
+
+        assertThat(converter).isEqualTo(new ByteConverter());
+        assertThat(converter).isNotEqualTo(new CharConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
@@ -164,4 +164,13 @@ public class CharConverterTest {
         CharConverter instance = new CharConverter();
         assertThat(instance.hashCode()).isEqualTo(CharConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        CharConverter converter = new CharConverter();
+
+        assertThat(converter).isEqualTo(new CharConverter());
+        assertThat(converter).isNotEqualTo(new ClassConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
@@ -79,4 +79,13 @@ public class ClassConverterTest {
         ClassConverter instance = new ClassConverter();
         assertThat(instance.hashCode()).isEqualTo(ClassConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        ClassConverter converter = new ClassConverter();
+
+        assertThat(converter).isEqualTo(new ClassConverter());
+        assertThat(converter).isNotEqualTo(new CurrencyConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
@@ -202,4 +202,13 @@ public class CurrencyConverterTest {
         CurrencyConverter instance = new CurrencyConverter();
         assertThat(instance.hashCode()).isEqualTo(CurrencyConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        CurrencyConverter converter = new CurrencyConverter();
+
+        assertThat(converter).isEqualTo(new CurrencyConverter());
+        assertThat(converter).isNotEqualTo(new DoubleConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
@@ -198,4 +198,12 @@ public class DoubleConverterTest {
         assertThat(instance.hashCode()).isEqualTo(DoubleConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        DoubleConverter converter = new DoubleConverter();
+
+        assertThat(converter).isEqualTo(new DoubleConverter());
+        assertThat(converter).isNotEqualTo(new DurationConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
@@ -92,4 +92,12 @@ public class DurationConverterTest {
         assertThat(instance.hashCode()).isEqualTo(DurationConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        DurationConverter converter = new DurationConverter();
+
+        assertThat(converter).isEqualTo(new DurationConverter());
+        assertThat(converter).isNotEqualTo(new FileConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
@@ -55,4 +55,13 @@ public class FileConverterTest {
         FileConverter instance = new FileConverter();
         assertThat(instance.hashCode()).isEqualTo(FileConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        FileConverter converter = new FileConverter();
+
+        assertThat(converter).isEqualTo(new FileConverter());
+        assertThat(converter).isNotEqualTo(new FloatConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
@@ -198,5 +198,12 @@ public class FloatConverterTest {
         assertThat(instance.hashCode()).isEqualTo(FloatConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        FloatConverter converter = new FloatConverter();
 
+        assertThat(converter).isEqualTo(new FloatConverter());
+        assertThat(converter).isNotEqualTo(new InstantConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
@@ -53,6 +53,8 @@ public class InstantConverterTest {
         InstantConverter conv2 = new InstantConverter();
         assertThat(conv2).isEqualTo(conv1);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
+        assertThat(conv1).isNotEqualTo(new IntegerConverter());
+        assertThat(conv1).isNotEqualTo(null);
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
@@ -53,6 +53,8 @@ public class LocalDateConverterTest {
         LocalDateConverter conv2 = new LocalDateConverter();
         assertThat(conv2).isEqualTo(conv1);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
+        assertThat(conv2).isNotEqualTo(null);
+        assertThat(conv2).isNotEqualTo(new LocalDateTimeConverter());
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
@@ -53,6 +53,8 @@ public class LocalDateTimeConverterTest {
         LocalDateTimeConverter conv2 = new LocalDateTimeConverter();
         assertThat(conv2).isEqualTo(conv1);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
+        assertThat(conv2).isNotEqualTo(new LocalTimeConverter());
+        assertThat(conv2).isNotEqualTo(null);
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
@@ -53,6 +53,8 @@ public class LocalTimeConverterTest {
         LocalTimeConverter conv2 = new LocalTimeConverter();
         assertThat(conv2).isEqualTo(conv1);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
+        assertThat(conv2).isNotEqualTo(new LongConverter());
+        assertThat(conv2).isNotEqualTo(null);
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
@@ -134,4 +134,13 @@ public class LongConverterTest {
         LongConverter instance = new LongConverter();
         assertThat(instance.hashCode()).isEqualTo(LongConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        LongConverter converter = new LongConverter();
+
+        assertThat(converter).isEqualTo(new LongConverter());
+        assertThat(converter).isNotEqualTo(new NumberConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
@@ -167,4 +167,13 @@ public class NumberConverterTest {
         NumberConverter instance = new NumberConverter();
         assertThat(instance.hashCode()).isEqualTo(NumberConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        NumberConverter converter = new NumberConverter();
+
+        assertThat(converter).isEqualTo(new NumberConverter());
+        assertThat(converter).isNotEqualTo(new OffsetDateTimeConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
@@ -54,6 +54,8 @@ public class OffsetDateTimeConverterTest {
         OffsetDateTimeConverter conv2 = new OffsetDateTimeConverter();
         assertThat(conv2).isEqualTo(conv1);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
+        assertThat(conv2).isNotEqualTo(new OffsetTimeConverter());
+        assertThat(conv2).isNotEqualTo(null);
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
@@ -52,6 +52,8 @@ public class OffsetTimeConverterTest {
         OffsetTimeConverter conv1 = new OffsetTimeConverter();
         OffsetTimeConverter conv2 = new OffsetTimeConverter();
         assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2).isNotEqualTo(new OptionalConverter());
+        assertThat(conv2).isNotEqualTo(null);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
@@ -74,4 +74,13 @@ public class OptionalConverterTest {
         OptionalConverter instance = new OptionalConverter();
         assertThat(instance.hashCode()).isEqualTo(OptionalConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        OptionalConverter converter = new OptionalConverter();
+
+        assertThat(converter).isEqualTo(new OptionalConverter());
+        assertThat(converter).isNotEqualTo(new PathConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
@@ -69,6 +69,8 @@ public class PathConverterTest {
         PathConverter conv1 = new PathConverter();
         PathConverter conv2 = new PathConverter();
         assertThat(conv2).isEqualTo(conv1);
+        assertThat(conv2).isNotEqualTo(new ShortConverter());
+        assertThat(conv2).isNotEqualTo(null);
         assertThat(conv2.hashCode()).isEqualTo(conv1.hashCode());
     }
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
@@ -135,4 +135,13 @@ public class ShortConverterTest {
         ShortConverter instance = new ShortConverter();
         assertThat(instance.hashCode()).isEqualTo(ShortConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        ShortConverter converter = new ShortConverter();
+
+        assertThat(converter).isEqualTo(new ShortConverter());
+        assertThat(converter).isNotEqualTo(new SupplierConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
@@ -73,6 +73,15 @@ public class SupplierConverterTest {
         assertThat(instance.hashCode()).isEqualTo(SupplierConverter.class.hashCode());
     }
 
+    @Test
+    public void testEquality() {
+        SupplierConverter converter = new SupplierConverter();
+
+        assertThat(converter).isEqualTo(new SupplierConverter());
+        assertThat(converter).isNotEqualTo(new URIConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
+
     private class MyConverter<T extends InetAddress> implements PropertyConverter<InetAddress> {
 
         @Override

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
@@ -86,6 +86,13 @@ public class URIConverterTest {
         URIConverter instance = new URIConverter();
         assertThat(instance.hashCode()).isEqualTo(URIConverter.class.hashCode());
     }
-    
-    
+
+    @Test
+    public void testEquality() {
+        URIConverter converter = new URIConverter();
+
+        assertThat(converter).isEqualTo(new URIConverter());
+        assertThat(converter).isNotEqualTo(new URLConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
@@ -87,4 +87,13 @@ public class URLConverterTest {
         URLConverter instance = new URLConverter();
         assertThat(instance.hashCode()).isEqualTo(URLConverter.class.hashCode());
     }
+
+    @Test
+    public void testEquality() {
+        URLConverter converter = new URLConverter();
+
+        assertThat(converter).isEqualTo(new URLConverter());
+        assertThat(converter).isNotEqualTo(new BigDecimalConverter());
+        assertThat(converter).isNotEqualTo(null);
+    }
 }


### PR DESCRIPTION
This adds a null check for arguments passed to ::equals methods in the
various converter classes.