### PR TITLE
TAMAYA-340 Bugfix for regex "\\." vs literal "."

### DIFF
--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySource.java
@@ -203,11 +203,11 @@ public class EnvironmentPropertySource extends BasePropertySource {
         String value = getPropertiesProvider().getenv(effectiveKey);
         // Replace all . by _ (i.e. com_ACME_size)
         if(value==null){
-            value = getPropertiesProvider().getenv(effectiveKey.replaceAll(".", "_"));
+            value = getPropertiesProvider().getenv(effectiveKey.replaceAll("\\.", "_"));
         }
         // Replace all . by _ and convert to upper case (i.e. COM_ACME_SIZE)
         if(value==null){
-            value = getPropertiesProvider().getenv(effectiveKey.replaceAll(".", "_")
+            value = getPropertiesProvider().getenv(effectiveKey.replaceAll("\\.", "_")
                     .toUpperCase());
         }
         return PropertyValue.of(key, value, getName());

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
@@ -97,6 +97,11 @@ public class EnvironmentPropertySourceTest {
 		assertThat(envPropertySource.getName()).isEqualTo("environment-properties");
 	}
 
+  @Test
+  public void testSingleCharacterNull() {
+    assertThat(envPropertySource.get("a")).isNull();
+  }
+
 	@Test
 	public void testGet() throws Exception {
 		for (Map.Entry<String, String> envEntry : System.getenv().entrySet()) {


### PR DESCRIPTION
String.replaceAll(String, String) takes a regex as its first argument,
not a literal replaceable string.  The result of this is that any
single-character environment variable is converted to use the "_" key
which has special significance to the system.  Tests in the extensions
repo include some that have a single character which this change should
get working again.  I've included a test in this repo for that case as
well.