### PR TITLE
Add Bundle-ActivationPolicy: lazy

### DIFF
--- a/code/core/bnd.bnd
+++ b/code/core/bnd.bnd
@@ -21,6 +21,7 @@ Bundle-Vendor: Apache Software Foundation
 Bundle-ContactAddress: dev-tamaya@incubator.apache.org
 Bundle-DocURL: http://tamaya.apache.org
 Bundle-Activator: org.apache.tamaya.core.OSGIActivator
+Bundle-ActivationPolicy: lazy
 Export-Package: \
 	org.apache.tamaya.core
 Import-Package: \


### PR DESCRIPTION
In this case the bundle gets automatically started, when one of its class get loaded.

So we don't have to start the bundle eagerly. It will be started automatically when its needed.