### PR TITLE
TAMAYA-349: Ensure Tamaya builds on JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 
 #before_script:
 #  - pip install --user codecov

--- a/code/api/src/main/java/org/apache/tamaya/TypeLiteral.java
+++ b/code/api/src/main/java/org/apache/tamaya/TypeLiteral.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * with current parameters.</p>
  *
  * <p>An object that represents a parameterized type may be obtained by
- * subclassing <tt>TypeLiteral</tt>.</p>
+ * subclassing {@link TypeLiteral}.</p>
  *
  * <pre>
  * TypeLiteral&lt;List&lt;Integer&gt;&gt; stringListType = new TypeLiteral&lt;List&lt;Integer&gt;&gt;() {};

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <enforcer.version>3.0.0-M1</enforcer.version>
         <gem.plugin>1.0.7</gem.plugin>
         <sources.plugin>3.0.1</sources.plugin>
-        <javadoc.version>3.0.0</javadoc.version>
+        <javadoc.version>3.0.1</javadoc.version>
         <!-- Must/should match the JRuby version used by AsciidoctorJ -->
         <jruby.version>1.7.26</jruby.version>
         <findbugs.version>3.0.4</findbugs.version>
@@ -300,7 +300,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.1</version>
+                    <version>0.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>


### PR DESCRIPTION
This updates the Javadoc plugin to 3.0.1 and the JaCoCo plugin to 0.8.2. It also fixes a javadoc tag that, apparently, is not valid under JDK 11.