### PR TITLE
Clean up OSGi/Manifest metadata

### DIFF
--- a/code/api/bnd.bnd
+++ b/code/api/bnd.bnd
@@ -19,7 +19,7 @@ Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
 Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya,\
 	org.apache.tamaya.spi

--- a/code/api/bnd.bnd
+++ b/code/api/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: API
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
 Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya,\

--- a/code/core/bnd.bnd
+++ b/code/core/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
 Bundle-DocURL: https://tamaya.apache.org
 Bundle-Activator: org.apache.tamaya.core.OSGIActivator
 Bundle-ActivationPolicy: lazy

--- a/code/core/bnd.bnd
+++ b/code/core/bnd.bnd
@@ -19,7 +19,7 @@ Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
 Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Bundle-Activator: org.apache.tamaya.core.OSGIActivator
 Bundle-ActivationPolicy: lazy
 Export-Package: \

--- a/code/spi-support/bnd.bnd
+++ b/code/spi-support/bnd.bnd
@@ -19,7 +19,7 @@ Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
 Bundle-ContactAddress: dev-tamaya@incubator.apache.org
-Bundle-DocURL: http://tamaya.apache.org
+Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.spisupport,org.apache.tamaya.spisupport.propertysource
 Import-Package: \

--- a/code/spi-support/bnd.bnd
+++ b/code/spi-support/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Category: Implementation
 Bundle-Copyright: (C) Apache Foundation
 Bundle-License: Apache Licence version 2
 Bundle-Vendor: Apache Software Foundation
-Bundle-ContactAddress: dev-tamaya@incubator.apache.org
+Bundle-ContactAddress: dev@tamaya.incubator.apache.org
 Bundle-DocURL: https://tamaya.apache.org
 Export-Package: \
 	org.apache.tamaya.spisupport,org.apache.tamaya.spisupport.propertysource

--- a/pom.xml
+++ b/pom.xml
@@ -516,25 +516,41 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                        <shortRevisionLength>8</shortRevisionLength>
+                    </configuration>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
                         <archive>
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                             <addMavenDescriptor>false</addMavenDescriptor>
+                            <manifest>
+                              <addDefaultImplementationEntries>false</addDefaultImplementationEntries>
+                            </manifest>
                             <manifestEntries>
-                                <Specification-Title>Apache
-                                    ${project.name}</Specification-Title>
+                                <Specification-Title>Apache ${project.name}</Specification-Title>
                                 <Specification-Version>${project.version}</Specification-Version>
-                                <Specification-Vendor>The Apache
-                                    Software Foundation</Specification-Vendor>
+                                <Specification-Vendor>The Apache Software Foundation</Specification-Vendor>
                                 <Implementation-Title>${project.name}</Implementation-Title>
-                                <Implementation-Version>${project.version}
-                                    ${buildNumber}</Implementation-Version>
-                                <Implementation-Vendor>The Apache
-                                    Software Foundation</Implementation-Vendor>
+                                <Implementation-Version>${project.version} ${buildNumber}</Implementation-Version>
+                                <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                                 <SCM-Revision>${buildNumber}</SCM-Revision>
-                                <SCM-url>${project.scm.url}</SCM-url>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -805,6 +821,10 @@
                     <source>${maven.compile.sourceLevel}</source>
                     <target>${maven.compile.targetLevel}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>


### PR DESCRIPTION
Related to TAMAYA-331

These changes are mostly cosmetic, removing extraneous whitespace from some `MANIFEST.MF` entries. Some `http` URLs are also changed to `https`. The `SCM-url` entry was removed because it produced an incorrect value (and it seems not possible to have it produce a correct value).

The manifest entries also seemed to be expecting a `${buildNumber}` value, but the `buildnumber-maven-plugin` wasn't included in the maven configuration; that has now been added.