### PR TITLE
TAMAYA-217: Simplify collection-based assertj tests

### DIFF
--- a/code/api/src/test/java/org/apache/tamaya/ConfigurationSnapshotTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigurationSnapshotTest.java
@@ -59,20 +59,17 @@ public class ConfigurationSnapshotTest {
 
     @Test
     public void testEMPTY_getOptional_Iterable(){
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"))).isNotNull();
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo")).isPresent()).isFalse();
+        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"))).isNotNull().isNotPresent();
     }
 
     @Test
     public void testEMPTY_getOptional_Class_Iterable(){
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), String.class)).isNotNull();
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), String.class).isPresent()).isFalse();
+        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), String.class)).isNotNull().isNotPresent();
     }
 
     @Test
     public void testEMPTY_getOptional_Typeliteral_Iterable(){
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), TypeLiteral.of(String.class))).isNotNull();
-        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), TypeLiteral.of(String.class)).isPresent()).isFalse();
+        assertThat(ConfigurationSnapshot.EMPTY.getOptional(Collections.singleton("foo"), TypeLiteral.of(String.class))).isNotNull().isNotPresent();
     }
 
     @Test
@@ -112,8 +109,7 @@ public class ConfigurationSnapshotTest {
 
     @Test
     public void testEMPTY_getKeys(){
-        assertThat(ConfigurationSnapshot.EMPTY.getKeys()).isNotNull();
-        assertThat(ConfigurationSnapshot.EMPTY.getKeys().isEmpty()).isTrue();
+        assertThat(ConfigurationSnapshot.EMPTY.getKeys()).isNotNull().isEmpty();
     }
 
     @Test
@@ -123,8 +119,7 @@ public class ConfigurationSnapshotTest {
 
     @Test
     public void testEMPTY_getPropertiest(){
-        assertThat(ConfigurationSnapshot.EMPTY.getProperties()).isNotNull();
-        assertThat(ConfigurationSnapshot.EMPTY.getProperties().isEmpty()).isTrue();
+        assertThat(ConfigurationSnapshot.EMPTY.getProperties()).isNotNull().isEmpty();
     }
 
     @Test

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationContextTest.java
@@ -31,16 +31,12 @@ public class ConfigurationContextTest {
     @Test
     public void test_EMPTY(){
         assertThat(ConfigurationContext.EMPTY.getPropertySource("foo")).isNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertySources()).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertySources().isEmpty()).isTrue();
+        assertThat(ConfigurationContext.EMPTY.getPropertySources()).isNotNull().isEmpty();
         assertThat(ConfigurationContext.EMPTY.getMetaData("foo")).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertyConverters()).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertyConverters().isEmpty()).isTrue();
-        assertThat(ConfigurationContext.EMPTY.getPropertyFilters()).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertyFilters().isEmpty()).isTrue();
+        assertThat(ConfigurationContext.EMPTY.getPropertyConverters()).isNotNull().isEmpty();
+        assertThat(ConfigurationContext.EMPTY.getPropertyFilters()).isNotNull().isEmpty();
         assertThat(ConfigurationContext.EMPTY.getServiceContext()).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertyConverters(TypeLiteral.of(Boolean.class))).isNotNull();
-        assertThat(ConfigurationContext.EMPTY.getPropertyConverters(TypeLiteral.of(Boolean.class)).isEmpty()).isTrue();
+        assertThat(ConfigurationContext.EMPTY.getPropertyConverters(TypeLiteral.of(Boolean.class))).isNotNull().isEmpty();
         assertThat(ConfigurationContext.EMPTY.toString()).isNotNull();
     }
 

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
@@ -84,7 +84,7 @@ public class ConversionContextTest {
                 < ctx.getSupportedFormats().indexOf(readable.get(1))).isTrue();
 
         ctx = new ConversionContext.Builder(TypeLiteral.of(List.class)).build();
-        assertThat(ctx.getSupportedFormats().isEmpty()).isTrue();
+        assertThat(ctx.getSupportedFormats()).isEmpty();
         ctx.addSupportedFormats(MyConverter.class, writeable.get(0), writeable.get(1));
         assertThat(ctx.getSupportedFormats().containsAll(readable)).isTrue();
         assertThat(ctx.getSupportedFormats().indexOf(readable.get(0))
@@ -103,8 +103,7 @@ public class ConversionContextTest {
         ConversionContext ctx = new ConversionContext.Builder("toString", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy")
                 .setValues(PropertyValue.createValue("test", "value")).build();
-        assertThat(ctx.getValues()).isNotNull();
-        assertThat(ctx.getValues().size()).isEqualTo(1);
+        assertThat(ctx.getValues()).isNotNull().hasSize(1);
         assertThat("value").isEqualTo(ctx.getValues().get(0).getValue());
         assertThat("test").isEqualTo(ctx.getValues().get(0).getKey());
     }
@@ -114,8 +113,7 @@ public class ConversionContextTest {
         ConversionContext ctx = new ConversionContext.Builder("toString", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy")
                 .setValues(Collections.singletonList(PropertyValue.createValue("test", "value"))).build();
-        assertThat(ctx.getValues()).isNotNull();
-        assertThat(ctx.getValues().size()).isEqualTo(1);
+        assertThat(ctx.getValues()).isNotNull().hasSize(1);
         assertThat("value").isEqualTo(ctx.getValues().get(0).getValue());
         assertThat("test").isEqualTo(ctx.getValues().get(0).getKey());
     }
@@ -134,21 +132,15 @@ public class ConversionContextTest {
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy")
                 .setValues(PropertyValue.createValue("test", "value")
                 .setMeta("meta1", "val1").setMeta("meta2", "val2")).build();
-        assertThat(ctx.getMeta()).isNotNull();
-        assertThat(ctx.getMeta().isEmpty()).isFalse();
-        assertThat(2).isEqualTo(ctx.getMeta().size());
+        assertThat(ctx.getMeta()).isNotNull().isNotEmpty().hasSize(2);
     }
 
     @Test
     public void testBuilderToString() {
         ConversionContext.Builder b = new ConversionContext.Builder("toString", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy");
-        assertThat(b.toString()).isNotNull();
-        assertThat(b.toString().contains("targetType=TypeLiteral{type=interface java.util.List}")).isTrue();
-        assertThat(b.toString().contains("supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]")).isTrue();
-        assertThat(b.toString().contains("annotatedElement")).isTrue();
-        assertThat(b.toString().contains("key='toString'")).isTrue();
-        assertThat(b.toString().contains("Builder")).isTrue();
+        assertThat(b.toString()).isNotNull().contains("targetType=TypeLiteral{type=interface java.util.List}",
+                "supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]", "annotatedElement", "key='toString'", "Builder");
     }
 
     private static final AnnotatedElement MyAnnotatedElement = new AnnotatedElement() {

--- a/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
@@ -41,7 +41,7 @@ public class FilterContextTest {
         assertThat(val).isEqualTo(ctx.getProperty());
         assertThat(ConfigurationContext.EMPTY).isEqualTo(ctx.getConfigurationContext());
         assertThat(ctx.getConfigEntries()).isNotNull();
-        assertThat(1).isEqualTo(ctx.getAllValues().size());
+        assertThat(ctx.getAllValues()).hasSize(1);
     }
 
 //    @Test
@@ -142,11 +142,8 @@ public class FilterContextTest {
 
         assertThat(toString).isNotNull();
         System.out.println(toString);
-        assertThat(toString.contains("FilterContext{value='[PropertyValue{'testToString', value='val'," +
-                " metaData={source=mySource}}]', configEntries=[")).isTrue();
-        assertThat(toString.contains("key-0")).isTrue();
-        assertThat(toString.contains("key-1")).isTrue();
-        assertThat(toString.endsWith("}")).isTrue();
+        assertThat(toString).contains("FilterContext{value='[PropertyValue{'testToString', value='val'," +
+                " metaData={source=mySource}}]', configEntries=[", "key-0", "key-1").endsWith("}");
     }
 
 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/ListValueTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ListValueTest.java
@@ -76,13 +76,11 @@ public class ListValueTest {
         lv.add(val);
         PropertyValue val2 = PropertyValue.createValue("k", "v");
         lv.add(val2);
-        assertThat(lv.getValues()).isNotNull();
-        assertThat(2).isEqualTo(lv.getValues().size());
+        assertThat(lv.getValues()).isNotNull().hasSize(2);
         assertThat(val).isEqualTo(lv.getValues().get(0));
         assertThat(val2).isEqualTo(lv.getValues().get(1));
         lv.add(val2);
-        assertThat(lv.getValues()).isNotNull();
-        assertThat(2).isEqualTo(lv.getValues().size());
+        assertThat(lv.getValues()).isNotNull().hasSize(2);
         assertThat(val).isEqualTo(lv.getValues().get(0));
         assertThat(val2).isEqualTo(lv.getValues().get(1));
     }
@@ -97,8 +95,7 @@ public class ListValueTest {
         List<PropertyValue> result = lv.getValues(
                 pv -> "k1".equals(pv.getKey())
         );
-        assertThat(result).isNotNull();
-        assertThat(1).isEqualTo(result.size());
+        assertThat(result).isNotNull().hasSize(1);
         assertThat(val).isEqualTo(result.get(0));
     }
 
@@ -211,10 +208,9 @@ public class ListValueTest {
         ListValue lv = PropertyValue.createList();
         lv.addList("list");
         lv.addObject("object");
-        assertThat(lv.getValues("")).isNotNull();
-        assertThat(0).isEqualTo(lv.getValues("").size());
-        assertThat(1).isEqualTo(lv.getValues("list").size());
-        assertThat(1).isEqualTo(lv.getValues("object").size());
+        assertThat(lv.getValues("")).isNotNull().hasSize(0);
+        assertThat(lv.getValues("list")).hasSize(1);
+        assertThat(lv.getValues("object")).hasSize(1);
     }
 
     @Test

--- a/code/api/src/test/java/org/apache/tamaya/spi/ObjectValueTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ObjectValueTest.java
@@ -80,13 +80,11 @@ public class ObjectValueTest {
         ov.set(val);
         PropertyValue val2 = PropertyValue.createValue("k2", "v");
         ov.set(val2);
-        assertThat(ov.getValues()).isNotNull();
-        assertThat(2).isEqualTo(ov.getValues().size());
+        assertThat(ov.getValues()).isNotNull().hasSize(2);
         assertThat(val).isEqualTo(ov.getValue("k1"));
         assertThat(val2).isEqualTo(ov.getValue("k2"));
         ov.set(val2);
-        assertThat(ov.getValues()).isNotNull();
-        assertThat(2).isEqualTo(ov.getValues().size());
+        assertThat(ov.getValues()).isNotNull().hasSize(2);
         assertThat(val).isEqualTo(ov.getValue("k1"));
         assertThat(val2).isEqualTo(ov.getValue("k2"));
     }
@@ -100,7 +98,7 @@ public class ObjectValueTest {
                 () -> PropertyValue.createValue("foo", "bar"));
         PropertyValue pv = ov.getOrSetValue("foo",  () -> PropertyValue.createValue("foo", "bar"));
         assertThat(pv).isNotNull();
-        assertThat(3).isEqualTo(ov.getValues().size());
+        assertThat(ov.getValues()).hasSize(3);
         assertThat(val).isEqualTo(ov.getValue("k1"));
         assertThat(val2).isEqualTo(ov.getValue("k2"));
         assertThat(pv).isEqualTo(ov.getValue("foo"));
@@ -215,8 +213,7 @@ public class ObjectValueTest {
         ov.setObject("k3");
         ov.setValue("k4", "v");
         Collection<PropertyValue> values = ov.getValues();
-        assertThat(values).isNotNull();
-        assertThat(4).isEqualTo(values.size());
+        assertThat(values).isNotNull().hasSize(4);
     }
 
     @Test
@@ -229,8 +226,7 @@ public class ObjectValueTest {
         Collection<PropertyValue> values = ov.getValues(
                 pv -> "k1".equals(pv.getKey())
         );
-        assertThat(values).isNotNull();
-        assertThat(1).isEqualTo(values.size());
+        assertThat(values).isNotNull().hasSize(1);
         assertThat("k1").isEqualTo(values.iterator().next().getKey());
     }
 
@@ -242,8 +238,7 @@ public class ObjectValueTest {
         ov.setObject("k3");
         ov.setValue("k4", "v");
         Collection<PropertyValue> values = ov.getValues();
-        assertThat(values).isNotNull();
-        assertThat(4).isEqualTo(values.size());
+        assertThat(values).isNotNull().hasSize(4);
     }
 
     @Test

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
@@ -29,7 +29,7 @@ public class PropertySourceProviderTest {
     @Test
     public void testEmptySourceProvider() {
         PropertySourceProvider instance = PropertySourceProvider.EMPTY;
-        assertThat(instance.getPropertySources().isEmpty()).isTrue();
+        assertThat(instance.getPropertySources()).isEmpty();
         assertThat(instance.toString()).isEqualTo("PropertySourceProvider(empty)");
     }
 }

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceTest.java
@@ -40,7 +40,7 @@ public class PropertySourceTest {
         assertThat(instance.getOrdinal()).isEqualTo(Integer.MIN_VALUE);
         assertThat(instance.getName()).isEqualTo("<empty>");
         assertThat(instance.get("key")).isNull();
-        assertThat(instance.getProperties().isEmpty()).isTrue();
+        assertThat(instance.getProperties()).isEmpty();
         assertThat(instance.toString()).isEqualTo("PropertySource.EMPTY");
 
     }

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertyValueTest.java
@@ -109,14 +109,12 @@ public class PropertyValueTest {
         PropertyValue pv = PropertyValue.createObject("k")
                 .setMeta(meta);
         assertThat(pv.getMeta()).isEqualTo(meta);
-        assertThat(pv.getMeta()).isEqualTo(meta);
     }
 
     @Test
     public void testGetMetaEntries2() throws Exception {
         PropertyValue pv = PropertyValue.of("k", "v", null);
-        assertThat(pv.getMeta()).isNotNull();
-        assertThat(pv.getMeta().isEmpty()).isTrue();
+        assertThat(pv.getMeta()).isNotNull().isEmpty();
     }
 
     @Test
@@ -125,8 +123,7 @@ public class PropertyValueTest {
         map.put("a", "b");
         map.put("b", "c");
         Map<String, PropertyValue> result = PropertyValue.map(map, "source");
-        assertThat(result).isNotNull();
-        assertThat(map.size()).isEqualTo(result.size());
+        assertThat(result).isNotNull().hasSize(map.size());
        for(PropertyValue pv:result.values()){
            assertThat("source").isEqualTo(pv.getMetaEntry("source"));
        }
@@ -143,8 +140,7 @@ public class PropertyValueTest {
         meta.put("m1", "m1v");
         meta.put("m2", "m2v");
         Map<String, PropertyValue> result = PropertyValue.map(map, "source", meta);
-        assertThat(result).isNotNull();
-        assertThat(map.size()).isEqualTo(result.size());
+        assertThat(result).isNotNull().hasSize(map.size());
         for(PropertyValue pv:result.values()){
             assertThat("source").isEqualTo(pv.getMetaEntry("source"));
             assertThat("m1v").isEqualTo(pv.getMeta("m1"));
@@ -432,7 +428,7 @@ public class PropertyValueTest {
         array.addValue("cVal2");
         Map<String,String> map = n.toMap();
         System.out.println(map);
-        assertThat(4).isEqualTo(map.size());
+        assertThat(map).hasSize(4);
         assertThat("aVal").isEqualTo(map.get("a"));
         assertThat("b3Val").isEqualTo(map.get("b.b2.b3"));
         assertThat("cVal1").isEqualTo(map.get("c[0]"));

--- a/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
@@ -100,8 +100,7 @@ public class ServiceContextTest {
     @Test
     public void testGetService() throws Exception {
         String service = serviceContext.getService(String.class);
-        assertThat(service).isNotNull();
-        assertThat(service).isEqualTo("ServiceContextTest");
+        assertThat(service).isNotNull().isEqualTo("ServiceContextTest");
         Integer intService = serviceContext.getService(Integer.class);
         assertThat(intService).isNull();
     }
@@ -109,12 +108,10 @@ public class ServiceContextTest {
     @Test
     public void testGetServices() throws Exception {
         Collection<String> services = serviceContext.getServices(String.class);
-        assertThat(services).isNotNull();
-        assertThat(services.isEmpty()).isFalse();
+        assertThat(services).isNotNull().isNotEmpty();
         assertThat(services.iterator().next()).isEqualTo("ServiceContextTest");
         List<Integer> intServices = serviceContext.getServices(Integer.class);
-        assertThat(intServices).isNotNull();
-        assertThat(intServices.isEmpty()).isTrue();
+        assertThat(intServices).isNotNull().isEmpty();
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
@@ -50,17 +50,13 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         // Ensure no sorting happens during add, so switch ordinals!
         testPS2 = new TestPropertySource("addPropertySources_Array", 1);
         b = Configuration.createConfigurationBuilder()
                 .addPropertySources(testPS2, testPropertySource);
         cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
         assertThat("addPropertySources_Array").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
     }
@@ -71,9 +67,7 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPropertySource, testPS2}));
         Configuration cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
         assertThat("addPropertySources_Collection").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
         // Ensure no sorting happens during add, so switch ordinals!
@@ -81,9 +75,7 @@ public class ConfigurationBuilderTest {
         b = Configuration.createConfigurationBuilder()
                 .addPropertySources(Arrays.asList(new PropertySource[]{testPS2, testPropertySource}));
         cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         assertThat("TestPropertySource").isEqualTo(cfg.getContext().getPropertySources().get(1).getName());
         assertThat("addPropertySources_Collection").isEqualTo(cfg.getContext().getPropertySources().get(0).getName());
     }
@@ -94,16 +86,12 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = Configuration.createConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         b = Configuration.createConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isFalse();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(1);
+        assertThat(cfg.getContext().getPropertySources()).hasSize(1).contains(testPS2).doesNotContain(testPropertySource);
     }
 
     @Test
@@ -112,16 +100,12 @@ public class ConfigurationBuilderTest {
         ConfigurationBuilder b = Configuration.createConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(2);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         b = Configuration.createConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(1);
-        assertThat(cfg.getContext().getPropertySources().contains(testPropertySource)).isFalse();
-        assertThat(cfg.getContext().getPropertySources().contains(testPS2)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).hasSize(1).doesNotContain(testPropertySource).contains(testPS2);
     }
 
     @Test
@@ -132,9 +116,7 @@ public class ConfigurationBuilderTest {
         b.addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = Configuration.createConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
@@ -149,9 +131,7 @@ public class ConfigurationBuilderTest {
         b.addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = Configuration.createConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
@@ -166,17 +146,13 @@ public class ConfigurationBuilderTest {
                 .addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyFilters(filter1, filter2);
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters()).hasSize(1);
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(1).doesNotContain(filter1).contains(filter2);
     }
 
     @Test
@@ -187,17 +163,13 @@ public class ConfigurationBuilderTest {
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyFilters(Arrays.asList(new PropertyFilter[]{filter1, filter2}));
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters()).hasSize(1);
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(1).doesNotContain(filter1).contains(filter2);
     }
 
     @Test
@@ -208,7 +180,7 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).contains(converter);
         assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
@@ -225,13 +197,13 @@ public class ConfigurationBuilderTest {
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
-        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).contains(converter);
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.addPropertyConverters(TypeLiteral.of(String.class), converter);
-        assertThat(1).isEqualTo(ctx.getPropertyConverters().size());
+        assertThat(ctx.getPropertyConverters()).hasSize(1);
     }
 
     @Test
@@ -242,15 +214,13 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1).contains(converter);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.removePropertyConverters(TypeLiteral.of(String.class), converter);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).isEmpty();
     }
 
 
@@ -262,15 +232,13 @@ public class ConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1).contains(converter);
         b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).isEmpty();
     }
 
     @Test
@@ -403,25 +371,25 @@ public class ConfigurationBuilderTest {
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
         assertThat(ctx).isNotNull();
-        assertThat(ctx.getPropertySources().isEmpty()).isTrue();
-        assertThat(ctx.getPropertyFilters().isEmpty()).isTrue();
+        assertThat(ctx.getPropertySources()).isEmpty();
+        assertThat(ctx.getPropertyFilters()).isEmpty();
     }
 
     @Test
     public void testRemoveAllFilters() throws Exception {
         ConfigurationBuilder b = Configuration.createConfigurationBuilder();
         b.addPropertyFilters((value, ctx) -> value.setValue(toString() + " - "));
-        assertThat(b.getPropertyFilters().isEmpty()).isFalse();
+        assertThat(b.getPropertyFilters()).isNotEmpty();
         b.removePropertyFilters(b.getPropertyFilters());
-        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
+        assertThat(b.getPropertyFilters()).isEmpty();
     }
 
     @Test
     public void testRemoveAllSources() throws Exception {
         ConfigurationBuilder b = Configuration.createConfigurationBuilder();
         b.addPropertySources(new TestPropertySource());
-        assertThat(b.getPropertySources().isEmpty()).isFalse();
+        assertThat(b.getPropertySources()).isNotEmpty();
         b.removePropertySources(b.getPropertySources());
-        assertThat(b.getPropertyFilters().isEmpty()).isTrue();
+        assertThat(b.getPropertyFilters()).isEmpty();
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/OSGIActivatorTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/OSGIActivatorTest.java
@@ -67,7 +67,7 @@ public class OSGIActivatorTest {
         //Start
         instance.start(mockBundleContext);
         assertThat(mockBundleContext.getBundleListenersCount()).isEqualTo(1);
-        assertThat(Configuration.current().getContext().getPropertyConverters().isEmpty()).isFalse();
+        assertThat(Configuration.current().getContext().getPropertyConverters()).isNotEmpty();
         assertThat(Configuration.current()).isNotSameAs(prevConfiguration);
 
         //Stop

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
@@ -64,9 +64,7 @@ public class CoreConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(2);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
     }
 
     @Test
@@ -76,17 +74,13 @@ public class CoreConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(2);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
         b = new CoreConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         b.removePropertySources(testPropertySource);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(1);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(1).contains(testPS2);
     }
 
     @Test
@@ -97,9 +91,7 @@ public class CoreConfigurationBuilderTest {
         b.addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = new CoreConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
         b.addPropertyFilters(filter1, filter2);
@@ -114,17 +106,13 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyFilters(filter1, filter2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
         b = new CoreConfigurationBuilder()
                 .addPropertyFilters(filter1, filter2);
         b.removePropertyFilters(filter1);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters()).hasSize(1);
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(1).contains(filter2);
     }
 
     @Test
@@ -135,7 +123,7 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).contains(converter);
         assertThat(ctx.getPropertyConverters()).hasSize(1);
         b = new CoreConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
@@ -151,15 +139,13 @@ public class CoreConfigurationBuilderTest {
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isTrue();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1);
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(1).contains(converter);
         b = new CoreConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         b.removePropertyConverters(TypeLiteral.of(String.class), converter);
         cfg = b.build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter)).isFalse();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).doesNotContain(converter).isEmpty();
     }
 
     @Test
@@ -178,23 +164,23 @@ public class CoreConfigurationBuilderTest {
         CoreConfigurationBuilder b = new CoreConfigurationBuilder();
         b.addCorePropertyConverters();
         Map<TypeLiteral<?>, List<PropertyConverter<?>>> converters = b.getPropertyConverter();
-        assertThat(converters.containsKey(TypeLiteral.<BigDecimal>of(BigDecimal.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<BigInteger>of(BigInteger.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Boolean>of(Boolean.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Byte>of(Byte.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Character>of(Character.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Class<?>>of(Class.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Currency>of(Currency.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Double>of(Double.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<File>of(File.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Float>of(Float.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Integer>of(Integer.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Long>of(Long.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Number>of(Number.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Path>of(Path.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<Short>of(Short.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<URI>of(URI.class))).isTrue();
-        assertThat(converters.containsKey(TypeLiteral.<URL>of(URL.class))).isTrue();
+        assertThat(converters).containsKey(TypeLiteral.<BigDecimal>of(BigDecimal.class));
+        assertThat(converters).containsKey(TypeLiteral.<BigInteger>of(BigInteger.class));
+        assertThat(converters).containsKey(TypeLiteral.<Boolean>of(Boolean.class));
+        assertThat(converters).containsKey(TypeLiteral.<Byte>of(Byte.class));
+        assertThat(converters).containsKey(TypeLiteral.<Character>of(Character.class));
+        assertThat(converters).containsKey(TypeLiteral.<Class<?>>of(Class.class));
+        assertThat(converters).containsKey(TypeLiteral.<Currency>of(Currency.class));
+        assertThat(converters).containsKey(TypeLiteral.<Double>of(Double.class));
+        assertThat(converters).containsKey(TypeLiteral.<File>of(File.class));
+        assertThat(converters).containsKey(TypeLiteral.<Float>of(Float.class));
+        assertThat(converters).containsKey(TypeLiteral.<Integer>of(Integer.class));
+        assertThat(converters).containsKey(TypeLiteral.<Long>of(Long.class));
+        assertThat(converters).containsKey(TypeLiteral.<Number>of(Number.class));
+        assertThat(converters).containsKey(TypeLiteral.<Path>of(Path.class));
+        assertThat(converters).containsKey(TypeLiteral.<Short>of(Short.class));
+        assertThat(converters).containsKey(TypeLiteral.<URI>of(URI.class));
+        assertThat(converters).containsKey(TypeLiteral.<URL>of(URL.class));
     }
 
     private static class TestPropertySource implements PropertySource{

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
@@ -35,10 +35,10 @@ public class CoreConfigurationTest {
     public void addPropertySources() throws Exception {
         TestPropertyDefaultSource def = new TestPropertyDefaultSource();
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertThat(cfg.getContext().getPropertySources().contains(def)).isFalse();
+        assertThat(cfg.getContext().getPropertySources()).doesNotContain(def);
         cfg = new CoreConfigurationBuilder()
                 .addPropertySources(def).build();
-        assertThat(cfg.getContext().getPropertySources().contains(def)).isTrue();
+        assertThat(cfg.getContext().getPropertySources()).contains(def);
     }
 
     @Test
@@ -49,11 +49,9 @@ public class CoreConfigurationTest {
     @Test
     public void getPropertySources() throws Exception {
         Configuration cfg = new CoreConfigurationBuilder().build();
-        assertThat(cfg.getContext().getPropertySources()).isNotNull();
-        assertThat(0).isEqualTo(cfg.getContext().getPropertySources().size());
+        assertThat(cfg.getContext().getPropertySources()).isNotNull().hasSize(0);
         cfg = new CoreConfigurationBuilder().addDefaultPropertySources().build();
-        assertThat(cfg.getContext().getPropertySources()).isNotNull();
-        assertThat(cfg.getContext().getPropertySources()).hasSize(7);
+        assertThat(cfg.getContext().getPropertySources()).isNotNull().hasSize(7);
     }
 
     @Test
@@ -61,9 +59,8 @@ public class CoreConfigurationTest {
         TestPropertyDefaultSource ps = new TestPropertyDefaultSource();
         Configuration cfg = new CoreConfigurationBuilder()
                 .addPropertySources(ps).build();
-        assertThat(cfg.getContext().getPropertySources()).isNotNull();
-        assertThat(1).isEqualTo(cfg.getContext().getPropertySources().size());
-        assertThat((cfg.getContext()).getPropertySource(ps.getName())).isNotNull();
+        assertThat(cfg.getContext().getPropertySources()).isNotNull().hasSize(1);
+        assertThat(cfg.getContext().getPropertySource(ps.getName())).isNotNull();
         assertThat(cfg.getContext().getPropertySource(ps.getName()).getName()).isEqualTo(ps.getName());
         assertThat(cfg.getContext().getPropertySource("huhu")).isNull();
 
@@ -92,9 +89,9 @@ public class CoreConfigurationTest {
                 return "";
             }
         };
-        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isFalse();
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).doesNotContain(testConverter);
         cfg = new CoreConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), testConverter).build();
-        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).contains(testConverter);
     }
 
     @Test
@@ -106,9 +103,8 @@ public class CoreConfigurationTest {
             }
         };
         Configuration cfg = new CoreConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), testConverter).build();
-        assertThat(cfg.getContext().getPropertyConverters()).isNotNull();
-        assertThat(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(String.class))).isTrue();
-        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters()).isNotNull().containsKey(TypeLiteral.of(String.class));
+        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(String.class))).contains(testConverter);
         testConverter = new PropertyConverter() {
             @Override
             public Object convert(String value, ConversionContext ctx) {
@@ -116,8 +112,8 @@ public class CoreConfigurationTest {
             }
         };
         cfg = new CoreConfigurationBuilder().addPropertyConverters(TypeLiteral.of(Integer.class), testConverter).build();
-        assertThat(cfg.getContext().getPropertyConverters().containsKey(TypeLiteral.of(Integer.class))).isTrue();
-        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(Integer.class)).contains(testConverter)).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters()).containsKey(TypeLiteral.of(Integer.class));
+        assertThat(cfg.getContext().getPropertyConverters().get(TypeLiteral.of(Integer.class))).contains(testConverter);
     }
 
     @Test
@@ -129,13 +125,10 @@ public class CoreConfigurationTest {
                 return "";
             }
         };
-        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull();
-        assertThat(0).isEqualTo(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size());
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull().hasSize(0);
 
         cfg = new CoreConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), testConverter).build();
-        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull();
-        assertThat(1).isEqualTo(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).size());
-        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class)).contains(testConverter)).isTrue();
+        assertThat(cfg.getContext().getPropertyConverters(TypeLiteral.of(String.class))).isNotNull().hasSize(1).contains(testConverter);
 
     }
 
@@ -149,10 +142,9 @@ public class CoreConfigurationTest {
                 return value;
             }
         };
-        assertThat(cfg.getContext().getPropertyFilters()).isNotNull();
-        assertThat(cfg.getContext().getPropertyFilters().contains(testFilter)).isFalse();
+        assertThat(cfg.getContext().getPropertyFilters()).isNotNull().doesNotContain(testFilter);
         cfg = cfg.toBuilder().addPropertyFilters(testFilter).build();
-        assertThat(cfg.getContext().getPropertyFilters().contains(testFilter)).isTrue();
+        assertThat(cfg.getContext().getPropertyFilters()).contains(testFilter);
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
@@ -34,14 +34,14 @@ public class DefaultJavaConfigurationTest {
             String key = "confkey" + i;
             String value = "javaconf-value" + i;
             // check if we had our key in configuration.current
-            assertThat(Configuration.current().getProperties().containsKey(key)).isTrue();
+            assertThat(Configuration.current().getProperties()).containsKey(key);
             assertThat(value).isEqualTo(Configuration.current().get(key));
         }
 
-        assertThat(Configuration.current().getProperties().containsKey("aaeehh")).isTrue();
+        assertThat(Configuration.current().getProperties()).containsKey("aaeehh");
         assertThat(Configuration.current().getProperties().get("aaeehh")).isEqualTo(A_UMLAUT);
 
-        assertThat(Configuration.current().getProperties().containsKey(O_UMLAUT)).isTrue();
+        assertThat(Configuration.current().getProperties()).containsKey(O_UMLAUT);
         assertThat(Configuration.current().getProperties().get(O_UMLAUT)).isEqualTo("o");
     }
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
@@ -82,7 +82,7 @@ public class OSGIServiceContextTest {
 
         List services = instance.getServices(Integer.class);
         assertThat(services).isNotNull();
-        assertThat(services.isEmpty()).isTrue();
+        assertThat(services).isEmpty();
     }
 
     /**
@@ -103,7 +103,7 @@ public class OSGIServiceContextTest {
         Enumeration<URL> resources = instance.getResources("dummy");
         assertThat(resources).isNotNull();
         URL resource = (URL)resources.nextElement();
-        assertThat(resource.toString().contains("mockbundle.service")).isTrue();
+        assertThat(resource.toString()).contains("mockbundle.service");
         assertThat(resources.hasMoreElements()).isFalse();
     }
 
@@ -123,7 +123,7 @@ public class OSGIServiceContextTest {
 
         URL resource = instance.getResource("mockbundle.service");
         assertThat(resource).isNotNull();
-        assertThat(resource.toString().contains("mockbundle.service")).isTrue();
+        assertThat(resource.toString()).contains("mockbundle.service");
     }
 
 }

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
@@ -57,7 +57,7 @@ public class OSGIServiceLoaderTest {
         mockBundleContext.installBundle(startedBundle);
         OSGIServiceLoader instance = new OSGIServiceLoader(mockBundleContext);
         Set<Bundle> result = instance.getResourceBundles();
-        assertThat(result.isEmpty()).isFalse();
+        assertThat(result).isNotEmpty();
     }
 
     /**

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
@@ -146,7 +146,7 @@ public class BigIntegerConverterTest {
         BigInteger value = converter.convert("", context);
 
         assertThat(value).isNull();
-        assertThat(context.getSupportedFormats().contains("<bigint> -> new BigInteger(bigint) (BigIntegerConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<bigint> -> new BigInteger(bigint) (BigIntegerConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BooleanConverterTest.java
@@ -137,8 +137,8 @@ public class BooleanConverterTest {
         BooleanConverter converter = new BooleanConverter();
         converter.convert("", context);
 
-        assertThat(context.getSupportedFormats().contains("true (ignore case) (BooleanConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("false (ignore case) (BooleanConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("true (ignore case) (BooleanConverter)",
+                "false (ignore case) (BooleanConverter)");
     }
     
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
@@ -100,9 +100,8 @@ public class ByteConverterTest {
         ByteConverter converter = new ByteConverter();
         converter.convert("", context);
 
-        assertThat(context.getSupportedFormats().contains("<byte> (ByteConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (ByteConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (ByteConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<byte> (ByteConverter)",
+                "MIN_VALUE (ByteConverter)", "MAX_VALUE (ByteConverter)");
     }
     
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
@@ -154,8 +154,7 @@ public class CharConverterTest {
         CharConverter converter = new CharConverter();
         converter.convert("", context);
 
-        assertThat(context.getSupportedFormats().contains("<char> (CharConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("\\'<char>\\' (CharConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<char> (CharConverter)", "\\'<char>\\' (CharConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
@@ -72,7 +72,7 @@ public class ClassConverterTest {
         ClassConverter converter = new ClassConverter();
         converter.convert("", context);
 
-        assertThat(context.getSupportedFormats().contains("<fullyQualifiedClassName> (ClassConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<fullyQualifiedClassName> (ClassConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CurrencyConverterTest.java
@@ -191,10 +191,8 @@ public class CurrencyConverterTest {
         CurrencyConverter converter = new CurrencyConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<numericValue> (CurrencyConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("<locale> (CurrencyConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("<currencyCode>, using Locale.ENGLISH (CurrencyConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<numericValue> (CurrencyConverter)",
+                "<locale> (CurrencyConverter)", "<currencyCode>, using Locale.ENGLISH (CurrencyConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
@@ -187,10 +187,8 @@ public class DoubleConverterTest {
         DoubleConverter converter = new DoubleConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<double> (DoubleConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (DoubleConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (DoubleConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<double> (DoubleConverter)",
+                    "MIN_VALUE (DoubleConverter)", "MAX_VALUE (DoubleConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
@@ -84,8 +84,7 @@ public class DurationConverterTest {
         DurationConverter converter = new DurationConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("PT20M34S (DurationConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("PT20M34S (DurationConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
@@ -50,7 +50,7 @@ public class FileConverterTest {
 
 
         assertThat(result).isNotNull();
-        assertThat(context.getSupportedFormats().contains("<File> (FileConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<File> (FileConverter)");
     }
     
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FloatConverterTest.java
@@ -187,9 +187,8 @@ public class FloatConverterTest {
         FloatConverter converter = new FloatConverter();
         converter.convert("", context);
 
-        assertThat(context.getSupportedFormats().contains("<float> (FloatConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (FloatConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (FloatConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<float> (FloatConverter)",
+                "MIN_VALUE (FloatConverter)", "MAX_VALUE (FloatConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
@@ -64,8 +64,7 @@ public class InstantConverterTest {
         InstantConverter converter = new InstantConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (InstantConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (InstantConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
@@ -124,10 +124,8 @@ public class IntegerConverterTest {
         IntegerConverter converter = new IntegerConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<int> (IntegerConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (IntegerConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (IntegerConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<int> (IntegerConverter)",
+                "MIN_VALUE (IntegerConverter)", "MAX_VALUE (IntegerConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
@@ -64,8 +64,7 @@ public class LocalDateConverterTest {
         LocalDateConverter converter = new LocalDateConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (LocalDateConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (LocalDateConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
@@ -64,8 +64,7 @@ public class LocalDateTimeConverterTest {
         LocalDateTimeConverter converter = new LocalDateTimeConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (LocalDateTimeConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (LocalDateTimeConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
@@ -64,8 +64,7 @@ public class LocalTimeConverterTest {
         LocalTimeConverter converter = new LocalTimeConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (LocalTimeConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (LocalTimeConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
@@ -125,9 +125,8 @@ public class LongConverterTest {
         converter.convert("", context);
 
 
-        assertThat(context.getSupportedFormats().contains("<long> (LongConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (LongConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (LongConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<long> (LongConverter)",
+                "MIN_VALUE (LongConverter)", "MAX_VALUE (LongConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
@@ -156,11 +156,8 @@ public class NumberConverterTest {
         NumberConverter converter = new NumberConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<double>, <long> (NumberConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("POSITIVE_INFINITY (NumberConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("NEGATIVE_INFINITY (NumberConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("NAN (NumberConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<double>, <long> (NumberConverter)",
+                "POSITIVE_INFINITY (NumberConverter)", "NEGATIVE_INFINITY (NumberConverter)", "NAN (NumberConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
@@ -64,8 +64,7 @@ public class OffsetDateTimeConverterTest {
         OffsetDateTimeConverter converter = new OffsetDateTimeConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (OffsetDateTimeConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (OffsetDateTimeConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
@@ -64,8 +64,7 @@ public class OffsetTimeConverterTest {
         OffsetTimeConverter converter = new OffsetTimeConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().toString().contains(" (OffsetTimeConverter)")).isTrue();
+        assertThat(context.getSupportedFormats().toString()).contains(" (OffsetTimeConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
@@ -81,8 +81,7 @@ public class PathConverterTest {
         PathConverter converter = new PathConverter();
         converter.convert("notempty", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<File> (PathConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<File> (PathConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
@@ -125,10 +125,8 @@ public class ShortConverterTest {
         ShortConverter converter = new ShortConverter();
         converter.convert("", context);
 
-
-        assertThat(context.getSupportedFormats().contains("short (ShortConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MIN_VALUE (ShortConverter)")).isTrue();
-        assertThat(context.getSupportedFormats().contains("MAX_VALUE (ShortConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("short (ShortConverter)",
+                "MIN_VALUE (ShortConverter)", "MAX_VALUE (ShortConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URIConverterTest.java
@@ -80,7 +80,7 @@ public class URIConverterTest {
         converter.convert("test:path", context);
 
 
-        assertThat(context.getSupportedFormats().contains("<uri> -> new URI(uri) (URIConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<uri> -> new URI(uri) (URIConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/URLConverterTest.java
@@ -80,8 +80,7 @@ public class URLConverterTest {
         URLConverter converter = new URLConverter();
         converter.convert("http://localhost", context);
 
-
-        assertThat(context.getSupportedFormats().contains("<URL> (URLConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<URL> (URLConverter)");
     }
 
     @Test

--- a/code/core/src/test/java/org/apache/tamaya/core/propertysource/BasePropertySourceTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/propertysource/BasePropertySourceTest.java
@@ -100,7 +100,7 @@ public class BasePropertySourceTest {
         assertThat(bs1).isNotEqualTo(bs3);
         assertThat(bs2.hashCode()).isEqualTo(bs1.hashCode());
         assertThat(bs1.hashCode()).isNotEqualTo(bs3.hashCode());
-        assertThat(bs1.toStringValues().contains("name='testEqualsName'")).isTrue();
+        assertThat(bs1.toStringValues()).contains("name='testEqualsName'");
     }
 
     private class EmptyPropertySource extends BasePropertySource {

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ConfigValueEvaluatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ConfigValueEvaluatorTest.java
@@ -57,13 +57,13 @@ public class ConfigValueEvaluatorTest {
     public void evaluteAllValues() {
         List<PropertyValue> values = evaluator.evaluateAllValues("foo", ConfigurationContext.EMPTY);
         assertThat(values).isNotNull();
-        assertThat(values.isEmpty()).isTrue();
+        assertThat(values).isEmpty();
     }
 
     @Test
     public void evaluateRawValues() {
         Map<String, PropertyValue> map = evaluator.evaluateRawValues(ConfigurationContext.EMPTY);
         assertThat(map).isNotNull();
-        assertThat(map.isEmpty()).isTrue();
+        assertThat(map).isEmpty();
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
@@ -52,7 +52,7 @@ public class DefaultConfigValueEvaluatorTest {
         Configuration config = Configuration.current();
         DefaultConfigValueEvaluator instance = new DefaultConfigValueEvaluator();
         Map<String, PropertyValue> result = instance.evaluateRawValues(config.getContext());
-        assertThat(result.containsKey("confkey1")).isTrue();
+        assertThat(result).containsKey("confkey1");
         assertThat(result.get("confkey1").getValue()).isEqualTo("javaconf-value1");
     }
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
@@ -60,17 +60,13 @@ public class DefaultConfigurationBuilderTest {
                 .addPropertySources(testPropertySource, testPS2);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(2);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
 
         b = new DefaultConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         cfg = b.removePropertySources(testPropertySource).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(1);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(1).contains(testPS2).doesNotContain(testPropertySource);
     }
 
     @Test
@@ -80,17 +76,13 @@ public class DefaultConfigurationBuilderTest {
                 .addPropertySources(Arrays.asList(testPropertySource, testPS2));
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(2);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isTrue();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(2).contains(testPropertySource, testPS2);
 
         b = new DefaultConfigurationBuilder()
                 .addPropertySources(testPropertySource, testPS2);
         cfg = b.removePropertySources(Arrays.asList(testPropertySource)).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertySources()).hasSize(1);
-        assertThat(ctx.getPropertySources().contains(testPropertySource)).isFalse();
-        assertThat(ctx.getPropertySources().contains(testPS2)).isTrue();
+        assertThat(ctx.getPropertySources()).hasSize(1).contains(testPS2).doesNotContain(testPropertySource);
     }
 
     @Test
@@ -100,9 +92,7 @@ public class DefaultConfigurationBuilderTest {
         DefaultConfigurationBuilder b = new DefaultConfigurationBuilder();
         Configuration cfg = b.addPropertyFilters(filter1, filter2).build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(filter1, filter2);
@@ -114,9 +104,7 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertyFilters(filter1, filter2);
         cfg = b.removePropertyFilters(filter1).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters()).hasSize(1);
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(1).contains(filter2).doesNotContain(filter1);
 
     }
 
@@ -127,9 +115,7 @@ public class DefaultConfigurationBuilderTest {
         DefaultConfigurationBuilder b = new DefaultConfigurationBuilder();
         Configuration cfg = b.addPropertyFilters(Arrays.asList(filter1, filter2)).build();
         ConfigurationContext ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isTrue();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
-        assertThat(ctx.getPropertyFilters()).hasSize(2);
+        assertThat(ctx.getPropertyFilters()).hasSize(2).contains(filter1, filter2);
 
         b = new DefaultConfigurationBuilder();
         b.addPropertyFilters(Arrays.asList(filter1, filter2, filter1));
@@ -141,9 +127,7 @@ public class DefaultConfigurationBuilderTest {
         b.addPropertyFilters(Arrays.asList(filter1, filter2));
         cfg = b.removePropertyFilters(Arrays.asList(filter1)).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyFilters()).hasSize(1);
-        assertThat(ctx.getPropertyFilters().contains(filter1)).isFalse();
-        assertThat(ctx.getPropertyFilters().contains(filter2)).isTrue();
+        assertThat(ctx.getPropertyFilters()).hasSize(1).contains(filter2).doesNotContain(filter1);
 
     }
 
@@ -309,10 +293,8 @@ public class DefaultConfigurationBuilderTest {
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
         Map<TypeLiteral<?>, List<PropertyConverter<?>>> buildConverters = b.getPropertyConverter();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isTrue();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2).contains(converter1, converter2);
         assertThat(ctx.getPropertyConverters()).hasSize(1);
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2);
         assertThat(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
                         ctx.getPropertyConverters().get(TypeLiteral.of(String.class)))).isTrue();
 
@@ -325,13 +307,12 @@ public class DefaultConfigurationBuilderTest {
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), converter1, converter2);
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class), converter1).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isFalse();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).contains(converter2).doesNotContain(converter1);
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), converter1, converter2);
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class)).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).isEmpty();
     }
 
     @Test
@@ -343,10 +324,8 @@ public class DefaultConfigurationBuilderTest {
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();
         Map<TypeLiteral<?>, List<PropertyConverter<?>>> buildConverters = b.getPropertyConverter();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isTrue();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2).contains(converter1, converter2);
         assertThat(ctx.getPropertyConverters()).hasSize(1);
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).hasSize(2);
         assertThat(buildConverters.get(TypeLiteral.of(String.class)).containsAll(
                         ctx.getPropertyConverters().get(TypeLiteral.of(String.class)))).isTrue();
 
@@ -359,13 +338,12 @@ public class DefaultConfigurationBuilderTest {
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1, converter2));
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1)).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter1)).isFalse();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).contains(converter2)).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).doesNotContain(converter1).contains(converter2);
 
         b = new DefaultConfigurationBuilder().addPropertyConverters(TypeLiteral.of(String.class), Arrays.asList(converter1, converter2));
         cfg = b.removePropertyConverters(TypeLiteral.of(String.class)).build();
         ctx = cfg.getContext();
-        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class)).isEmpty()).isTrue();
+        assertThat(ctx.getPropertyConverters(TypeLiteral.of(String.class))).isEmpty();
     }
 
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
@@ -58,6 +58,6 @@ public class DefaultConfigurationContextTest {
         assertThat(ctx1.hashCode()).isNotEqualTo(ctx3.hashCode());
         String spaces = new String(new char[70 - sharedSource.getName().length()]).replace("\0", " ");
         System.out.println(ctx1.toString());
-        assertThat(ctx3.toString().contains(sharedSource.getName() + spaces)).isTrue();
+        assertThat(ctx3.toString()).contains(sharedSource.getName() + spaces);
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshotTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshotTest.java
@@ -106,9 +106,9 @@ public class DefaultConfigurationSnapshotTest {
         Configuration config = Configuration.current();
         DefaultConfigurationSnapshot snapshot = new DefaultConfigurationSnapshot(config,
                 Arrays.asList("confkey1", "confkey2", "confkey3"));
-        assertThat(config.getContext().getPropertySources().size()).isEqualTo(snapshot.getContext().getPropertySources().size());
-        assertThat(config.getContext().getPropertyConverters().size()).isEqualTo(snapshot.getContext().getPropertyConverters().size());
-        assertThat(config.getContext().getPropertyFilters().size()).isEqualTo(snapshot.getContext().getPropertyFilters().size());
+        assertThat(snapshot.getContext().getPropertySources()).hasSize(config.getContext().getPropertySources().size());
+        assertThat(snapshot.getContext().getPropertyConverters()).hasSize(config.getContext().getPropertyConverters().size());
+        assertThat(snapshot.getContext().getPropertyFilters()).hasSize(config.getContext().getPropertyFilters().size());
     }
 
     @Test
@@ -222,11 +222,11 @@ public class DefaultConfigurationSnapshotTest {
         Configuration config = Configuration.current();
         DefaultConfigurationSnapshot snapshot = new DefaultConfigurationSnapshot(config,
                 Arrays.asList("confkey1", "confkey2", "confkey3"));
-        assertThat(snapshot.getKeys().contains("confkey1")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey2")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey3")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey4")).isFalse();
-        assertThat(snapshot.getKeys().contains("foo")).isFalse();
+        assertThat(snapshot.getKeys()).contains("confkey1");
+        assertThat(snapshot.getKeys()).contains("confkey2");
+        assertThat(snapshot.getKeys()).contains("confkey3");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey4");
+        assertThat(snapshot.getKeys()).doesNotContain("foo");
     }
 
     @Test
@@ -234,23 +234,23 @@ public class DefaultConfigurationSnapshotTest {
         Configuration config = Configuration.current();
         ConfigurationSnapshot snapshot = new DefaultConfigurationSnapshot(config,
                 Arrays.asList("confkey1", "confkey2", "confkey3"));
-        assertThat(snapshot.getKeys().contains("confkey1")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey2")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey3")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey4")).isFalse();
-        assertThat(snapshot.getKeys().contains("foo")).isFalse();
+        assertThat(snapshot.getKeys()).contains("confkey1");
+        assertThat(snapshot.getKeys()).contains("confkey2");
+        assertThat(snapshot.getKeys()).contains("confkey3");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey4");
+        assertThat(snapshot.getKeys()).doesNotContain("foo");
         snapshot = snapshot.getSnapshot(Arrays.asList("confkey1", "confkey2"));
-        assertThat(snapshot.getKeys().contains("confkey1")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey2")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey3")).isFalse();
-        assertThat(snapshot.getKeys().contains("confkey4")).isFalse();
-        assertThat(snapshot.getKeys().contains("foo")).isFalse();
+        assertThat(snapshot.getKeys()).contains("confkey1");
+        assertThat(snapshot.getKeys()).contains("confkey2");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey3");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey4");
+        assertThat(snapshot.getKeys()).doesNotContain("foo");
         snapshot = snapshot.getSnapshot(Arrays.asList("confkey1", "foo"));
-        assertThat(snapshot.getKeys().contains("confkey1")).isTrue();
-        assertThat(snapshot.getKeys().contains("confkey2")).isFalse();
-        assertThat(snapshot.getKeys().contains("confkey3")).isFalse();
-        assertThat(snapshot.getKeys().contains("confkey4")).isFalse();
-        assertThat(snapshot.getKeys().contains("foo")).isTrue();
+        assertThat(snapshot.getKeys()).contains("confkey1");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey2");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey3");
+        assertThat(snapshot.getKeys()).doesNotContain("confkey4");
+        assertThat(snapshot.getKeys()).contains("foo");
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
@@ -277,7 +277,7 @@ public class DefaultConfigurationTest {
         assertThat(config1).isNotEqualTo(config3);
         assertThat(config2.hashCode()).isEqualTo(config1.hashCode());
         assertThat(config1.hashCode()).isNotEqualTo(config3.hashCode());
-        assertThat(config1.toString().contains("Configuration{")).isTrue();
+        assertThat(config1.toString()).contains("Configuration{");
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
@@ -57,8 +57,7 @@ public class DefaultMetaDataProviderTest {
         DefaultMetaDataProvider provider = new DefaultMetaDataProvider();
         assertThat(provider).isEqualTo(provider.init(ConfigurationContext.EMPTY));
         provider.setMeta("foo", "a", "b");
-        assertThat(provider.getMetaData("foo")).isNotNull();
-        assertThat(1).isEqualTo(provider.getMetaData("foo").size());
+        assertThat(provider.getMetaData("foo")).isNotNull().hasSize(1);
     }
 
     @Test
@@ -68,8 +67,7 @@ public class DefaultMetaDataProviderTest {
         Map<String,String> map = new HashMap<>();
         map.put("a", "b");
         provider.setMeta("foo", map);
-        assertThat(provider.getMetaData("foo")).isNotNull();
-        assertThat(1).isEqualTo(provider.getMetaData("foo").size());
+        assertThat(provider.getMetaData("foo")).isNotNull().hasSize(1);
 
     }
 
@@ -78,8 +76,7 @@ public class DefaultMetaDataProviderTest {
         DefaultMetaDataProvider provider = new DefaultMetaDataProvider();
         assertThat(provider).isEqualTo(provider.init(ConfigurationContext.EMPTY));
         provider.reset();
-        assertThat(provider.getMetaData("foo")).isNotNull();
-        assertThat(provider.getMetaData("foo").isEmpty()).isTrue();
+        assertThat(provider.getMetaData("foo")).isNotNull().isEmpty();
     }
 
     @Test
@@ -87,8 +84,7 @@ public class DefaultMetaDataProviderTest {
         DefaultMetaDataProvider provider = new DefaultMetaDataProvider();
         assertThat(provider).isEqualTo(provider.init(ConfigurationContext.EMPTY));
         provider.reset();
-        assertThat(provider.getMetaData("foo")).isNotNull();
-        assertThat(provider.getMetaData("foo").isEmpty()).isTrue();
+        assertThat(provider.getMetaData("foo")).isNotNull().isEmpty();
     }
 
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultPropertySourceSnapshotTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultPropertySourceSnapshotTest.java
@@ -69,7 +69,7 @@ public class DefaultPropertySourceSnapshotTest {
         PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
         assertThat(ps).isNotNull();
         assertThat(ps.getProperties()).isNotNull();
-        assertThat(ps.getProperties().isEmpty()).isFalse();
+        assertThat(ps.getProperties()).isNotEmpty();
         for(Map.Entry en:myPS.getProperties().entrySet()){
             assertThat(en.getValue()).isEqualTo(ps.get((String)en.getKey()));
         }
@@ -80,7 +80,7 @@ public class DefaultPropertySourceSnapshotTest {
         PropertySource ps1 = DefaultPropertySourceSnapshot.of(myPS);
         PropertySource ps2 = DefaultPropertySourceSnapshot.of(myPS);
         assertThat(ps1.getName()).isEqualTo(ps2.getName());
-        assertThat(ps1.getProperties().size()).isEqualTo(ps2.getProperties().size());
+        assertThat(ps1.getProperties()).hasSize(ps2.getProperties().size());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class DefaultPropertySourceSnapshotTest {
         PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
         String toString = ps.toString();
         assertThat(toString).isNotNull();
-        assertThat(toString.contains("FrozenPropertySource")).isTrue();
-        assertThat(toString.contains(myPS.getName())).isTrue();
+        assertThat(toString).contains("FrozenPropertySource");
+        assertThat(toString).contains(myPS.getName());
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
@@ -102,7 +102,7 @@ public class DefaultServiceContextTest {
     public void testGetServices_noImpl_shouldReturnEmptyList() {
         Collection<NoImplInterface> services = context.getServices(NoImplInterface.class);
         assertThat(services).isNotNull();
-        assertThat(services.isEmpty()).isTrue();
+        assertThat(services).isEmpty();
     }
 
     @Test
@@ -116,9 +116,7 @@ public class DefaultServiceContextTest {
     public void testRegister_Many() throws Exception {
         context.register(Double.class, Arrays.asList(Double.valueOf(1.2345), Double.valueOf(2345), Double.valueOf(345)), false);
         List<Double> services = context.getServices(Double.class);
-        assertThat(services).isNotNull();
-        assertThat(services.isEmpty()).isFalse();
-        assertThat(services.size()).isEqualTo(3);
+        assertThat(services).isNotNull().isNotEmpty().hasSize(3);
     }
 
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
@@ -66,7 +66,7 @@ public class EnumConverterTest {
         ConversionContext context = new ConversionContext.Builder("someKey", TypeLiteral.of(Enum.class)).build();
         EnumConverter<RoundingMode> converter = new EnumConverter<>(RoundingMode.class);
         converter.convert("fooBars", context);
-        assertThat(context.getSupportedFormats().contains("<enumValue> (EnumConverter)")).isTrue();
+        assertThat(context.getSupportedFormats()).contains("<enumValue> (EnumConverter)");
     }
 
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
@@ -133,7 +133,7 @@ public class PropertySourceChangeSupportTest {
         PropertySourceChangeSupport support = new PropertySourceChangeSupport(ChangeSupport.IMMUTABLE, ps);
         Map properties = support.getProperties();
         assertThat(properties).isNotNull();
-        assertThat(properties.isEmpty()).isTrue();
+        assertThat(properties).isEmpty();
         support.load(ps.getProperties());
         properties = support.getProperties();
         assertThat(properties).isNotNull();

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
@@ -79,7 +79,6 @@ public class RegexPropertyFilterTest {
     public void testToString() throws Exception {
         RegexPropertyFilter filter = new RegexPropertyFilter();
         filter.setIncludes("test\\..*");
-        assertThat(filter.toString().contains("test\\..*")).isTrue();
-        assertThat(filter.toString().contains("RegexPropertyFilter")).isTrue();
+        assertThat(filter.toString()).contains("test\\..*", "RegexPropertyFilter");
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
@@ -99,7 +99,7 @@ public class BasePropertySourceTest {
         assertThat(bs1).isNotEqualTo(bs3);
         assertThat(bs2.hashCode()).isEqualTo(bs1.hashCode());
         assertThat(bs1.hashCode()).isNotEqualTo(bs3.hashCode());
-        assertThat(bs1.toStringValues().contains("name='testEqualsName'")).isTrue();
+        assertThat(bs1.toStringValues()).contains("name='testEqualsName'");
     }
 
     private class EmptyPropertySource extends BasePropertySource {

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
@@ -39,43 +39,43 @@ public class CLIPropertySourceTest {
             System.clearProperty("main.args");
             
             CLIPropertySource ps = new CLIPropertySource();
-            assertThat(ps.getProperties().isEmpty()).isTrue();
+            assertThat(ps.getProperties()).isEmpty();
             
             ps = new CLIPropertySource(26);
-            assertThat(ps.getProperties().isEmpty()).isTrue();
+            assertThat(ps.getProperties()).isEmpty();
             assertThat(ps.getOrdinal()).isEqualTo(26);
             
             ps = new CLIPropertySource("-a", "b");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
-            assertThat(ps.toStringValues().contains("args=[-a, b]")).isTrue();
+            assertThat(ps.toStringValues()).contains("args=[-a, b]");
             
             ps = new CLIPropertySource(16, "-c", "d");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("d").isEqualTo(ps.getProperties().get("c").getValue());
             assertThat(ps.getOrdinal()).isEqualTo(16);
             
             CLIPropertySource.initMainArgs("-e", "f");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("f").isEqualTo(ps.getProperties().get("e").getValue());
             
             CLIPropertySource.initMainArgs("--g");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("g").isEqualTo(ps.getProperties().get("g").getValue());
             
             CLIPropertySource.initMainArgs("sss");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("sss").isEqualTo(ps.getProperties().get("sss").getValue());
             
             CLIPropertySource.initMainArgs("-a", "b", "--c", "sss", "--val=vvv");
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
             assertThat("c").isEqualTo(ps.getProperties().get("c").getValue());
             assertThat("sss").isEqualTo(ps.getProperties().get("sss").getValue());
             
             System.setProperty("main.args", "-a b\t--c sss  ");
             ps = new CLIPropertySource();
-            assertThat(ps.getProperties().isEmpty()).isFalse();
+            assertThat(ps.getProperties()).isNotEmpty();
             System.clearProperty("main.args");
             assertThat("b").isEqualTo(ps.getProperties().get("a").getValue());
             assertThat("c").isEqualTo(ps.getProperties().get("c").getValue());

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
@@ -53,9 +53,9 @@ public class EnvironmentPropertySourceTest {
 			assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
 			assertThat(localEnvironmentPropertySource.get(System.getenv().entrySet().iterator().next().getKey()))
 					.isNull();
-			assertThat(localEnvironmentPropertySource.getName().contains("(disabled)")).isTrue();
-			assertThat(localEnvironmentPropertySource.getProperties().isEmpty()).isTrue();
-			assertThat(localEnvironmentPropertySource.toString().contains("disabled=true")).isTrue();
+			assertThat(localEnvironmentPropertySource.getName()).contains("(disabled)");
+			assertThat(localEnvironmentPropertySource.getProperties()).isEmpty();
+			assertThat(localEnvironmentPropertySource.toString()).contains("disabled=true");
 
 			System.getProperties().clear();
 			System.getProperties().load(new StringReader(before));

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
@@ -60,8 +60,8 @@ public class JavaConfigurationProviderTest {
             System.setProperty("tamaya.defaultprops.disable", "true");
             localJavaConfigurationPropertySource = new JavaConfigurationPropertySource();
             assertThat(localJavaConfigurationPropertySource.isEnabled()).isFalse();
-            assertThat(localJavaConfigurationPropertySource.getProperties().isEmpty()).isTrue();
-            assertThat(localJavaConfigurationPropertySource.toString().contains("enabled=false")).isTrue();
+            assertThat(localJavaConfigurationPropertySource.getProperties()).isEmpty();
+            assertThat(localJavaConfigurationPropertySource.toString()).contains("enabled=false");
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
@@ -50,11 +50,6 @@ public class PropertiesFilePropertySourceTest {
 
     @Test
     public void testGetProperties() throws Exception {
-        assertThat(testfilePropertySource.getProperties()).hasSize(5);
-        assertThat(testfilePropertySource.getProperties().containsKey("key1")).isTrue();
-        assertThat(testfilePropertySource.getProperties().containsKey("key2")).isTrue();
-        assertThat(testfilePropertySource.getProperties().containsKey("key3")).isTrue();
-        assertThat(testfilePropertySource.getProperties().containsKey("key4")).isTrue();
-        assertThat(testfilePropertySource.getProperties().containsKey("key5")).isTrue();
+        assertThat(testfilePropertySource.getProperties()).hasSize(5).containsKeys("key1", "key2", "key3", "key4", "key5");
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
@@ -36,16 +36,14 @@ public class PropertiesResourcePropertySourceTest {
     public void testBasicConstructor() {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(resource);
         assertThat(source).isNotNull();
-        assertThat(5 == source.getProperties().size()).isTrue(); // double the getNumChilds for .source values.
-        assertThat(source.getProperties().containsKey("key1")).isTrue();
+        assertThat(source.getProperties()).hasSize(5).containsKey("key1"); // double the getNumChilds for .source values.
     }
 
     @Test
     public void testPrefixedConstructor() {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(resource, "somePrefix");
         assertThat(source).isNotNull();
-        assertThat(5 == source.getProperties().size()).isTrue();
-        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
+        assertThat(source.getProperties()).hasSize(5).containsKey("somePrefixkey1");
     }
 
     @Test
@@ -54,8 +52,7 @@ public class PropertiesResourcePropertySourceTest {
         System.out.println(resource.getPath());
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix");
         assertThat(source).isNotNull();
-        assertThat(5 == source.getProperties().size()).isTrue();
-        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
+        assertThat(source.getProperties()).hasSize(5).containsKey("somePrefixkey1");
     }
     
     @Test
@@ -68,7 +65,7 @@ public class PropertiesResourcePropertySourceTest {
         };
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix", badLoader);
         assertThat(source).isNotNull();
-        assertThat(source.getProperties().isEmpty()).isTrue();
+        assertThat(source.getProperties()).isEmpty();
     }
     
     @Test
@@ -76,8 +73,7 @@ public class PropertiesResourcePropertySourceTest {
         PropertiesResourcePropertySource source = new PropertiesResourcePropertySource(testFileName, "somePrefix",
                 getClass().getClassLoader());
         assertThat(source).isNotNull();
-        assertThat(5 == source.getProperties().size()).isTrue();
-        assertThat(source.getProperties().containsKey("somePrefixkey1")).isTrue();
+        assertThat(source.getProperties()).hasSize(5).containsKey("somePrefixkey1");
     }
 
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
@@ -147,7 +147,7 @@ public class SimplePropertySourceTest {
         SimplePropertySource source = new SimplePropertySource("testWithMap", propertyFirst, 166);
         assertThat(source.getName()).isEqualTo("testWithMap");
         assertThat(source.getDefaultOrdinal()).isEqualTo(166);
-        assertThat(source.getProperties().containsKey("firstKey")).isTrue();
+        assertThat(source.getProperties()).containsKey("firstKey");
 
     }
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySourceTest.java
@@ -51,35 +51,35 @@ public class SystemPropertySourceTest {
         String before = stringBufferWriter.toString();
 
         try {
-            assertThat(testPropertySource.toStringValues().contains("disabled=true")).isFalse();
+            assertThat(testPropertySource.toStringValues()).doesNotContain("disabled=true");
 
             System.setProperty("tamaya.sysprops.prefix", "fakeprefix");
             System.setProperty("tamaya.sysprops.disable", "true");
             localSystemPropertySource = new SystemPropertySource();
             //assertThat(localSystemPropertySource.getPrefix()).isEqualTo("fakeprefix");
-            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isTrue();
+            assertThat(localSystemPropertySource.toStringValues()).contains("disabled=true");
             assertThat(localSystemPropertySource.get(System.getenv().entrySet().iterator().next().getKey())).isNull();
-            assertThat(localSystemPropertySource.getName().contains("(disabled)")).isTrue();
-            assertThat(localSystemPropertySource.getProperties().isEmpty()).isTrue();
-            assertThat(localSystemPropertySource.toString().contains("disabled=true")).isTrue();
+            assertThat(localSystemPropertySource.getName()).contains("(disabled)");
+            assertThat(localSystemPropertySource.getProperties()).isEmpty();
+            assertThat(localSystemPropertySource.toString()).contains("disabled=true");
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "true");
             localSystemPropertySource = new SystemPropertySource();
-            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isTrue();
+            assertThat(localSystemPropertySource.toStringValues()).contains("disabled=true");
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.sysprops.disable", "");
             localSystemPropertySource = new SystemPropertySource();
-            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isFalse();
+            assertThat(localSystemPropertySource.toStringValues()).doesNotContain("disabled=true");
 
             System.getProperties().clear();
             System.getProperties().load(new StringReader(before));
             System.setProperty("tamaya.defaults.disable", "");
             localSystemPropertySource = new SystemPropertySource();
-            assertThat(localSystemPropertySource.toStringValues().contains("disabled=true")).isFalse();
+            assertThat(localSystemPropertySource.toStringValues()).doesNotContain("disabled=true");
 
         } finally {
             System.getProperties().clear();

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
@@ -91,8 +91,7 @@ public class WrappedPropertySourceTest {
     public void testGetProperties() {
         WrappedPropertySource instance = WrappedPropertySource.of(new MockedWrappablePropertySource());
         Map<String, PropertyValue> result = instance.getProperties();
-        assertThat(result.containsKey("someKey")).isTrue();
-        assertThat(result).hasSize(1);
+        assertThat(result).hasSize(1).containsKey("someKey");
     }
 
     /**
@@ -126,7 +125,7 @@ public class WrappedPropertySourceTest {
         assertThat(wps1).isNotEqualTo(wps3);
         assertThat(wps2.hashCode()).isEqualTo(wps1.hashCode());
         assertThat(wps1.hashCode()).isNotEqualTo(wps3.hashCode());
-        assertThat(wps1.toString().contains("name=testEqualsName")).isTrue();
+        assertThat(wps1.toString()).contains("name=testEqualsName");
     }
 
     private class MockedWrappablePropertySource implements PropertySource{


### PR DESCRIPTION
This cleans up the AssertJ test code, making more effective use of the built-in container support in AssertJ.

For example:

```java
assertThat(myCollection.size()).isEqualTo(5);
```

is changed to:

```java
assertThat(myCollection).hasSize(5);
```

and

```java
assertThat(myCollection.contains("foo")).isTrue();
```

is changed to:

```java
assertThat(myCollection).contains("foo");
```