### PR TITLE
TAMAYA-219: Update checkstyle plugin and configuration

### DIFF
--- a/code/api/pom.xml
+++ b/code/api/pom.xml
@@ -47,6 +47,10 @@ under the License.
                     </newArtifacts>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -87,6 +87,10 @@ under the License.
                 </configuration>
             </plugin>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/code/spi-support/pom.xml
+++ b/code/spi-support/pom.xml
@@ -47,6 +47,10 @@ under the License.
                     </newArtifacts>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -399,15 +399,10 @@
                     </executions>
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
-                        <configLocation>checkstyle/style.xml</configLocation>
+                        <configLocation>buildconfigurations/src/main/resources/checkstyle/style.xml</configLocation>
                         <failOnViolation>false</failOnViolation>
                     </configuration>
                     <dependencies>
-                        <dependency>
-                            <groupId>org.apache.tamaya</groupId>
-                            <artifactId>buildconfigurations</artifactId>
-                            <version>${project.version}</version>
-                        </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <asciidoctor.version>1.5.6</asciidoctor.version>
         <asciidoctor-diagramm.version>1.2.1</asciidoctor-diagramm.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
-        <checkstyle.version>2.15</checkstyle.version>
+        <checkstyle.version>3.0.0</checkstyle.version>
         <!-- 201801: v1.3.x gives strange test errors -->
         <pitest-plugin.version>1.2.5</pitest-plugin.version>
         <enforcer.version>3.0.0-M1</enforcer.version>
@@ -390,8 +390,8 @@
                     <version>${checkstyle.version}</version>
                     <executions>
                         <execution>
-                            <id>verify-style</id>
-                            <phase>process-classes</phase>
+                            <id>checkstyle</id>
+                            <phase>validate</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>
@@ -400,8 +400,8 @@
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <configLocation>checkstyle/style.xml</configLocation>
+                        <failOnViolation>false</failOnViolation>
                     </configuration>
-
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.tamaya</groupId>
@@ -411,7 +411,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.3</version>
+                            <version>7.8</version>
                             <exclusions><!-- MCHECKSTYLE-156 -->
                                 <exclusion>
                                     <groupId>com.sun</groupId>


### PR DESCRIPTION
This enables the checkstyle plugin for the maven verify phase,
and updates the plugin to a more recent version.