### PR TITLE
TAMAYA-379: Enforce checkstyle for the main codebase

### DIFF
--- a/buildconfigurations/src/main/resources/checkstyle/style.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/style.xml
@@ -85,7 +85,7 @@ under the License.
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="AvoidStarImport">
             <property name="excludes"
-                      value="java.io,java.net,java.util"/>
+                      value="java.io,java.net,java.util,java.lang.annotation,org.osgi.framework,org.apache.tamaya,org.apache.tamaya.spi,org.apache.tamaya.core.internal.converters"/>
         </module>
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>

--- a/code/api/src/main/java/org/apache/tamaya/ConfigQuery.java
+++ b/code/api/src/main/java/org/apache/tamaya/ConfigQuery.java
@@ -23,6 +23,7 @@ package org.apache.tamaya;
  * to model additional functionality and applying it to a given {@link Configuration} instance by
  * calling the {@link Configuration#query(ConfigQuery)} method.
  *
+ * @param <T> the config query type
  * @deprecated Use {@link java.util.function.Function}
  */
 @FunctionalInterface

--- a/code/api/src/main/java/org/apache/tamaya/TypeLiteral.java
+++ b/code/api/src/main/java/org/apache/tamaya/TypeLiteral.java
@@ -123,7 +123,7 @@ public class TypeLiteral<T> implements Serializable {
      * @return the actual type represented by this createObject
      */
     @SuppressWarnings("unchecked")
-	public final Class<T> getRawType() {
+    public final Class<T> getRawType() {
         Class<T> rawType;
 
         if (this.definedType instanceof ParameterizedType) {

--- a/code/api/src/main/java/org/apache/tamaya/spi/ListValue.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/ListValue.java
@@ -182,9 +182,7 @@ public final class ListValue extends PropertyValue{
      */
     public List<PropertyValue> getValues(Predicate<PropertyValue> filter) {
         List<PropertyValue> result = new ArrayList<>();
-        this.list.forEach(el -> {
-                if (filter.test(el)) result.add(el);
-            });
+        this.list.stream().filter(filter::test).forEach(result::add);
         return result;
     }
 
@@ -320,8 +318,12 @@ public final class ListValue extends PropertyValue{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ListValue)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ListValue)) {
+            return false;
+        }
         ListValue dataNode = (ListValue) o;
         return Objects.equals(getKey(), dataNode.getKey()) &&
                 Objects.equals(getValue(), dataNode.getValue()) &&

--- a/code/api/src/main/java/org/apache/tamaya/spi/ObjectValue.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/ObjectValue.java
@@ -295,8 +295,12 @@ public final class ObjectValue extends PropertyValue{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ObjectValue)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ObjectValue)) {
+            return false;
+        }
         ObjectValue dataNode = (ObjectValue) o;
         return Objects.equals(getKey(), dataNode.getKey()) &&
                 Objects.equals(fields, dataNode.fields) &&

--- a/code/api/src/main/java/org/apache/tamaya/spi/PropertyConverter.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/PropertyConverter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.tamaya.spi;
 
-import java.util.List;
-
 /**
  * Interface for an property that converts a configured String into something else.
  * This is used for implementing type conversion from a property (String) to a certain target

--- a/code/api/src/main/java/org/apache/tamaya/spi/PropertyValue.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/PropertyValue.java
@@ -579,8 +579,12 @@ public class PropertyValue implements Serializable, Iterable<PropertyValue>{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof PropertyValue)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PropertyValue)) {
+            return false;
+        }
         PropertyValue dataNode = (PropertyValue) o;
         return Objects.equals(getKey(), dataNode.getKey()) &&
                 Objects.equals(value, dataNode.value) &&

--- a/code/core/src/main/java/org/apache/tamaya/core/OSGIActivator.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/OSGIActivator.java
@@ -21,7 +21,9 @@ package org.apache.tamaya.core;
 
 
 import org.apache.tamaya.Configuration;
-import org.apache.tamaya.core.internal.*;
+import org.apache.tamaya.core.internal.CoreConfigurationBuilder;
+import org.apache.tamaya.core.internal.OSGIServiceContext;
+import org.apache.tamaya.core.internal.OSGIServiceLoader;
 import org.apache.tamaya.spi.ServiceContextManager;
 import org.apache.tamaya.spisupport.PropertyFilterComparator;
 import org.apache.tamaya.spisupport.PropertySourceComparator;

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/BannerManager.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/BannerManager.java
@@ -63,6 +63,9 @@ class BannerManager {
      */
     protected final static String BANNER_RESOURCE_PATH = "/tamaya-banner.txt";
 
+    /**
+     * The target for the Tamaya banner output.
+     */
     enum BannerTarget {
         OFF, CONSOLE, LOGGER
     }
@@ -98,6 +101,9 @@ class BannerManager {
     }
 }
 
+/**
+ * An abstract Tamaya banner printer.
+ */
 abstract class AbstractBannerPrinter implements BannerPrinter {
     private static final Logger log = Logger.getLogger(AbstractBannerPrinter.class.getName());
 

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/CoreConfigurationBuilder.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/CoreConfigurationBuilder.java
@@ -63,7 +63,7 @@ public final class CoreConfigurationBuilder extends DefaultConfigurationBuilder 
     }
 
     @SuppressWarnings("unchecked")
-	protected void addCorePropertyConverters() {
+    protected void addCorePropertyConverters() {
         addPropertyConverters(TypeLiteral.<BigDecimal>of(BigDecimal.class), new BigDecimalConverter());
         addPropertyConverters(TypeLiteral.<BigInteger>of(BigInteger.class), new BigIntegerConverter());
         addPropertyConverters(TypeLiteral.<Boolean>of(Boolean.class), new BooleanConverter());

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/OSGIServiceLoader.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/OSGIServiceLoader.java
@@ -37,218 +37,217 @@ import org.osgi.framework.*;
  */
 @SuppressWarnings("rawtypes")
 public class OSGIServiceLoader implements BundleListener {
-	// Provide logging
-	private static final Logger log = Logger.getLogger(OSGIServiceLoader.class.getName());
-	private static final String META_INF_SERVICES = "META-INF/services/";
+    // Provide logging
+    private static final Logger log = Logger.getLogger(OSGIServiceLoader.class.getName());
+    private static final String META_INF_SERVICES = "META-INF/services/";
 
-	private BundleContext context;
+    private BundleContext context;
 
-	private Set<Bundle> resourceBundles = Collections.synchronizedSet(new HashSet<Bundle>());
+    private Set<Bundle> resourceBundles = Collections.synchronizedSet(new HashSet<Bundle>());
 
-	public OSGIServiceLoader(BundleContext context) {
-		this.context = Objects.requireNonNull(context);
-		// Check for matching bundles already installed...
-		for (Bundle bundle : context.getBundles()) {
-			switch (bundle.getState()) {
-			case Bundle.ACTIVE:
-				checkAndLoadBundle(bundle);
-			}
-		}
-	}
+    public OSGIServiceLoader(BundleContext context) {
+        this.context = Objects.requireNonNull(context);
+        // Check for matching bundles already installed...
+        for (Bundle bundle : context.getBundles()) {
+            if (bundle.getState() == Bundle.ACTIVE) {
+                checkAndLoadBundle(bundle);
+            }
+        }
+    }
 
-	public BundleContext getBundleContext() {
-		return context;
-	}
+    public BundleContext getBundleContext() {
+        return context;
+    }
 
-	public Set<Bundle> getResourceBundles() {
-		synchronized (resourceBundles) {
-			return new HashSet<>(resourceBundles);
-		}
-	}
+    public Set<Bundle> getResourceBundles() {
+        synchronized (resourceBundles) {
+            return new HashSet<>(resourceBundles);
+        }
+    }
 
-	@Override
-	public void bundleChanged(BundleEvent bundleEvent) {
-		// Parse and createObject metadata when installed
-		if (bundleEvent.getType() == BundleEvent.STARTED) {
-			Bundle bundle = bundleEvent.getBundle();
-			checkAndLoadBundle(bundle);
-		} else if (bundleEvent.getType() == BundleEvent.STOPPED) {
-			Bundle bundle = bundleEvent.getBundle();
-			checkAndUnloadBundle(bundle);
-		}
-	}
+    @Override
+    public void bundleChanged(BundleEvent bundleEvent) {
+        // Parse and createObject metadata when installed
+        if (bundleEvent.getType() == BundleEvent.STARTED) {
+            Bundle bundle = bundleEvent.getBundle();
+            checkAndLoadBundle(bundle);
+        } else if (bundleEvent.getType() == BundleEvent.STOPPED) {
+            Bundle bundle = bundleEvent.getBundle();
+            checkAndUnloadBundle(bundle);
+        }
+    }
 
-	private void checkAndUnloadBundle(Bundle bundle) {
-		if (bundle.getEntry(META_INF_SERVICES) == null) {
-			return;
-		}
-		synchronized (resourceBundles) {
-			resourceBundles.remove(bundle);
-			log.fine("Unregistered ServiceLoader bundle: " + bundle.getSymbolicName());
-		}
-		Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
-		while (entryPaths.hasMoreElements()) {
-			String entryPath = entryPaths.nextElement();
-			if (!entryPath.endsWith("/")) {
-				removeEntryPath(bundle, entryPath);
-			}
-		}
-	}
+    private void checkAndUnloadBundle(Bundle bundle) {
+        if (bundle.getEntry(META_INF_SERVICES) == null) {
+            return;
+        }
+        synchronized (resourceBundles) {
+            resourceBundles.remove(bundle);
+            log.fine("Unregistered ServiceLoader bundle: " + bundle.getSymbolicName());
+        }
+        Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
+        while (entryPaths.hasMoreElements()) {
+            String entryPath = entryPaths.nextElement();
+            if (!entryPath.endsWith("/")) {
+                removeEntryPath(bundle, entryPath);
+            }
+        }
+    }
 
-	private void checkAndLoadBundle(Bundle bundle) {
-		if (bundle.getEntry(META_INF_SERVICES) == null) {
-			return;
-		}
-		synchronized (resourceBundles) {
-			resourceBundles.add(bundle);
-			log.info("Registered ServiceLoader bundle: " + bundle.getSymbolicName());
-		}
-		Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
-		while (entryPaths.hasMoreElements()) {
-			String entryPath = entryPaths.nextElement();
-			if (!entryPath.endsWith("/")) {
-				processEntryPath(bundle, entryPath);
-			}
-		}
-	}
+    private void checkAndLoadBundle(Bundle bundle) {
+        if (bundle.getEntry(META_INF_SERVICES) == null) {
+            return;
+        }
+        synchronized (resourceBundles) {
+            resourceBundles.add(bundle);
+            log.info("Registered ServiceLoader bundle: " + bundle.getSymbolicName());
+        }
+        Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
+        while (entryPaths.hasMoreElements()) {
+            String entryPath = entryPaths.nextElement();
+            if (!entryPath.endsWith("/")) {
+                processEntryPath(bundle, entryPath);
+            }
+        }
+    }
 
-	private void processEntryPath(Bundle bundle, String entryPath) {
-		try {
-			String serviceName = entryPath.substring(META_INF_SERVICES.length());
-			if (!serviceName.startsWith("org.apache.tamaya")) {
-				// Ignore non Tamaya entries...
-				return;
-			}
-			Class<?> serviceClass = bundle.loadClass(serviceName);
-			URL child = bundle.getEntry(entryPath);
-			InputStream inStream = child.openStream();
-			log.info("Loading Services " + serviceClass.getName() + " from bundle...: " + bundle.getSymbolicName());
-			try (BufferedReader br = new BufferedReader(new InputStreamReader(inStream, "UTF-8"))) {
-				String implClassName = br.readLine();
-				while (implClassName != null) {
-					int hashIndex = implClassName.indexOf("#");
-					if (hashIndex > 0) {
-						implClassName = implClassName.substring(0, hashIndex - 1);
-					} else if (hashIndex == 0) {
-						implClassName = "";
-					}
-					implClassName = implClassName.trim();
-					if (implClassName.length() > 0) {
-						try {
-							// Load the service class
-							log.fine("Loading Class " + implClassName + " from bundle...: " + bundle.getSymbolicName());
-							Class<?> implClass = bundle.loadClass(implClassName);
-							if (!serviceClass.isAssignableFrom(implClass)) {
-								log.warning("Configured service: " + implClassName + " is not assignable to "
-										+ serviceClass.getName());
-								continue;
-							}
-							log.info("Loaded Service Factory (" + serviceName + "): " + implClassName);
-							// Provide service properties
-							Hashtable<String, String> props = new Hashtable<>();
-							props.put(Constants.VERSION_ATTRIBUTE, bundle.getVersion().toString());
-							String vendor = bundle.getHeaders().get(Constants.BUNDLE_VENDOR);
-							props.put(Constants.SERVICE_VENDOR, (vendor != null ? vendor : "anonymous"));
-							// Translate annotated @Priority into a service ranking
-							props.put(Constants.SERVICE_RANKING,
-									String.valueOf(PriorityServiceComparator.getPriority(implClass)));
+    private void processEntryPath(Bundle bundle, String entryPath) {
+        try {
+            String serviceName = entryPath.substring(META_INF_SERVICES.length());
+            if (!serviceName.startsWith("org.apache.tamaya")) {
+                // Ignore non Tamaya entries...
+                return;
+            }
+            Class<?> serviceClass = bundle.loadClass(serviceName);
+            URL child = bundle.getEntry(entryPath);
+            InputStream inStream = child.openStream();
+            log.info("Loading Services " + serviceClass.getName() + " from bundle...: " + bundle.getSymbolicName());
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(inStream, "UTF-8"))) {
+                String implClassName = br.readLine();
+                while (implClassName != null) {
+                    int hashIndex = implClassName.indexOf("#");
+                    if (hashIndex > 0) {
+                        implClassName = implClassName.substring(0, hashIndex - 1);
+                    } else if (hashIndex == 0) {
+                        implClassName = "";
+                    }
+                    implClassName = implClassName.trim();
+                    if (implClassName.length() > 0) {
+                        try {
+                            // Load the service class
+                            log.fine("Loading Class " + implClassName + " from bundle...: " + bundle.getSymbolicName());
+                            Class<?> implClass = bundle.loadClass(implClassName);
+                            if (!serviceClass.isAssignableFrom(implClass)) {
+                                log.warning("Configured service: " + implClassName + " is not assignable to "
+                                        + serviceClass.getName());
+                                continue;
+                            }
+                            log.info("Loaded Service Factory (" + serviceName + "): " + implClassName);
+                            // Provide service properties
+                            Hashtable<String, String> props = new Hashtable<>();
+                            props.put(Constants.VERSION_ATTRIBUTE, bundle.getVersion().toString());
+                            String vendor = bundle.getHeaders().get(Constants.BUNDLE_VENDOR);
+                            props.put(Constants.SERVICE_VENDOR, (vendor != null ? vendor : "anonymous"));
+                            // Translate annotated @Priority into a service ranking
+                            props.put(Constants.SERVICE_RANKING,
+                                    String.valueOf(PriorityServiceComparator.getPriority(implClass)));
 
-							// Register the service factory on behalf of the intercepted bundle
-							JDKUtilServiceFactory factory = new JDKUtilServiceFactory(implClass);
-							BundleContext bundleContext = bundle.getBundleContext();
-							bundleContext.registerService(serviceName, factory, props);
-							log.info("Registered Tamaya service class: " + implClassName + "(" + serviceName + ")");
-						} catch (Exception e) {
-							log.log(Level.SEVERE, "Failed to load service: " + implClassName, e);
-						} catch (NoClassDefFoundError err) {
-							log.log(Level.SEVERE, "Failed to load service: " + implClassName, err);
-						}
-					}
-					implClassName = br.readLine();
-				}
-			}
-		} catch (RuntimeException rte) {
-			throw rte;
-		} catch (Exception e) {
-			log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
-		}
-	}
+                            // Register the service factory on behalf of the intercepted bundle
+                            JDKUtilServiceFactory factory = new JDKUtilServiceFactory(implClass);
+                            BundleContext bundleContext = bundle.getBundleContext();
+                            bundleContext.registerService(serviceName, factory, props);
+                            log.info("Registered Tamaya service class: " + implClassName + "(" + serviceName + ")");
+                        } catch (Exception e) {
+                            log.log(Level.SEVERE, "Failed to load service: " + implClassName, e);
+                        } catch (NoClassDefFoundError err) {
+                            log.log(Level.SEVERE, "Failed to load service: " + implClassName, err);
+                        }
+                    }
+                    implClassName = br.readLine();
+                }
+            }
+        } catch (RuntimeException rte) {
+            throw rte;
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
+        }
+    }
 
-	private void removeEntryPath(Bundle bundle, String entryPath) {
-		try {
-			String serviceName = entryPath.substring(META_INF_SERVICES.length());
-			if (!serviceName.startsWith("org.apache.tamaya")) {
-				// Ignore non Tamaya entries...
-				return;
-			}
-			Class<?> serviceClass = bundle.loadClass(serviceName);
+    private void removeEntryPath(Bundle bundle, String entryPath) {
+        try {
+            String serviceName = entryPath.substring(META_INF_SERVICES.length());
+            if (!serviceName.startsWith("org.apache.tamaya")) {
+                // Ignore non Tamaya entries...
+                return;
+            }
+            Class<?> serviceClass = bundle.loadClass(serviceName);
 
-			URL child = bundle.getEntry(entryPath);
-			InputStream inStream = child.openStream();
+            URL child = bundle.getEntry(entryPath);
+            InputStream inStream = child.openStream();
 
-			BufferedReader br = new BufferedReader(new InputStreamReader(inStream, "UTF-8"));
-			String implClassName = br.readLine();
-			while (implClassName != null) {
-				int hashIndex = implClassName.indexOf("#");
-				if (hashIndex > 0) {
-					implClassName = implClassName.substring(0, hashIndex - 1);
-				} else if (hashIndex == 0) {
-					implClassName = "";
-				}
-				implClassName = implClassName.trim();
-				if (implClassName.length() > 0) {
-					log.fine("Unloading Service (" + serviceName + "): " + implClassName);
-					try {
-						// Load the service class
-						Class<?> implClass = bundle.loadClass(implClassName);
-						if (!serviceClass.isAssignableFrom(implClass)) {
-							log.warning("Configured service: " + implClassName + " is not assignable to "
-									+ serviceClass.getName());
-							continue;
-						}
-						ServiceReference<?> ref = bundle.getBundleContext().getServiceReference(implClass);
-						if (ref != null) {
-							bundle.getBundleContext().ungetService(ref);
-						}
-					} catch (Exception e) {
-						log.log(Level.SEVERE, "Failed to unload service: " + implClassName, e);
-					} catch (NoClassDefFoundError err) {
-						log.log(Level.SEVERE, "Failed to unload service: " + implClassName, err);
-					}
-				}
-				implClassName = br.readLine();
-			}
-			br.close();
-		} catch (RuntimeException rte) {
-			throw rte;
-		} catch (Exception e) {
-			log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
-		}
-	}
+            BufferedReader br = new BufferedReader(new InputStreamReader(inStream, "UTF-8"));
+            String implClassName = br.readLine();
+            while (implClassName != null) {
+                int hashIndex = implClassName.indexOf("#");
+                if (hashIndex > 0) {
+                    implClassName = implClassName.substring(0, hashIndex - 1);
+                } else if (hashIndex == 0) {
+                    implClassName = "";
+                }
+                implClassName = implClassName.trim();
+                if (implClassName.length() > 0) {
+                    log.fine("Unloading Service (" + serviceName + "): " + implClassName);
+                    try {
+                        // Load the service class
+                        Class<?> implClass = bundle.loadClass(implClassName);
+                        if (!serviceClass.isAssignableFrom(implClass)) {
+                            log.warning("Configured service: " + implClassName + " is not assignable to "
+                                    + serviceClass.getName());
+                            continue;
+                        }
+                        ServiceReference<?> ref = bundle.getBundleContext().getServiceReference(implClass);
+                        if (ref != null) {
+                            bundle.getBundleContext().ungetService(ref);
+                        }
+                    } catch (Exception e) {
+                        log.log(Level.SEVERE, "Failed to unload service: " + implClassName, e);
+                    } catch (NoClassDefFoundError err) {
+                        log.log(Level.SEVERE, "Failed to unload service: " + implClassName, err);
+                    }
+                }
+                implClassName = br.readLine();
+            }
+            br.close();
+        } catch (RuntimeException rte) {
+            throw rte;
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
+        }
+    }
 
-	/**
-	 * Service factory simply instantiating the configured service.
-	 */
-	static class JDKUtilServiceFactory implements ServiceFactory {
-		private final Class<?> serviceClass;
+    /**
+     * Service factory simply instantiating the configured service.
+     */
+    static class JDKUtilServiceFactory implements ServiceFactory {
+        private final Class<?> serviceClass;
 
-		public JDKUtilServiceFactory(Class<?> serviceClass) {
-			this.serviceClass = serviceClass;
-		}
+        public JDKUtilServiceFactory(Class<?> serviceClass) {
+            this.serviceClass = serviceClass;
+        }
 
-		@Override
-		public Object getService(Bundle bundle, ServiceRegistration registration) {
-			try {
-				log.fine("Creating Service...:" + serviceClass.getName());
-				return serviceClass.getConstructor().newInstance();
-			} catch (Exception ex) {
-				ex.printStackTrace();
-				throw new IllegalStateException("Failed to createObject service: " + serviceClass.getName(), ex);
-			}
-		}
+        @Override
+        public Object getService(Bundle bundle, ServiceRegistration registration) {
+            try {
+                log.fine("Creating Service...:" + serviceClass.getName());
+                return serviceClass.getConstructor().newInstance();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                throw new IllegalStateException("Failed to createObject service: " + serviceClass.getName(), ex);
+            }
+        }
 
-		@Override
-		public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
-		}
-	}
+        @Override
+        public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
+        }
+    }
 }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ByteConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ByteConverter.java
@@ -64,10 +64,9 @@ public class ByteConverter implements PropertyConverter<Byte>{
             case "MAX":
                 return Byte.MAX_VALUE;
             default:
-                try{
+                try {
                     return Byte.decode(trimmed);
-                }
-                catch(Exception e){
+                } catch(Exception e) {
                     LOG.log(Level.FINEST, "Unparseable Byte: " + value);
                     return null;
                 }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ClassConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ClassConverter.java
@@ -45,22 +45,19 @@ public class ClassConverter implements PropertyConverter<Class<?>>{
         }
         ctx.addSupportedFormats(getClass(),"<fullyQualifiedClassName>");
         String trimmed = Objects.requireNonNull(value).trim();
-        try{
+        try {
             return Class.forName(trimmed, false, Thread.currentThread().getContextClassLoader());
-        }
-        catch(Exception e){
+        } catch(Exception e) {
             LOG.finest("Class not found in context CL: " + trimmed);
         }
-        try{
+        try {
             return Class.forName(trimmed, false, ClassConverter.class.getClassLoader());
-        }
-        catch(Exception e){
+        } catch(Exception e) {
             LOG.finest("Class not found in ClassConverter's CL: " + trimmed);
         }
-        try{
+        try {
             return Class.forName(trimmed, false, ClassLoader.getSystemClassLoader());
-        }
-        catch(Exception e){
+        } catch(Exception e) {
             LOG.finest("Class not found in System CL (giving up): " + trimmed);
             return null;
         }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/IntegerConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/IntegerConverter.java
@@ -66,10 +66,9 @@ public class IntegerConverter implements PropertyConverter<Integer>{
             case "MAX":
                 return Integer.MAX_VALUE;
             default:
-                try{
+                try {
                     return Integer.decode(trimmed);
-                }
-                catch(Exception e){
+                } catch(Exception e) {
                     LOG.finest("Unparseable Integer createValue: " + trimmed);
                     return null;
                 }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LongConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/LongConverter.java
@@ -66,8 +66,7 @@ public class LongConverter implements PropertyConverter<Long>{
                 default:
                     try {
                         return Long.decode(trimmed);
-                    }
-                    catch(Exception e){
+                    } catch(Exception e) {
                         LOGGER.finest("Unable to parse Long createValue: " + value);
                         return null;
                     }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/NumberConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/NumberConverter.java
@@ -65,10 +65,9 @@ public class NumberConverter implements PropertyConverter<Number>{
                 if (lVal != null) {
                     return lVal;
                 }
-                try{
+                try {
                     return new BigDecimal(trimmed);
-                }
-                catch(Exception e){
+                } catch(Exception e) {
                     LOGGER.finest("Unparseable Number: " + trimmed);
                     return null;
                 }

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ShortConverter.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/converters/ShortConverter.java
@@ -64,10 +64,9 @@ public class ShortConverter implements PropertyConverter<Short>{
             case "MAX":
                 return Short.MAX_VALUE;
             default:
-                try{
+                try {
                     return Short.decode(trimmed);
-                }
-                catch(Exception e){
+                } catch(Exception e) {
                     LOG.finest("Unparseable Short: " + trimmed);
                     return null;
                 }

--- a/code/core/src/main/java/org/apache/tamaya/core/propertysource/BasePropertySource.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/propertysource/BasePropertySource.java
@@ -146,8 +146,12 @@ public abstract class BasePropertySource implements PropertySource{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BasePropertySource that = (BasePropertySource) o;
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfiguration.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfiguration.java
@@ -203,7 +203,7 @@ public class DefaultConfiguration implements Configuration {
     }
 
     @SuppressWarnings("unchecked")
-	protected <T> T convertValue(String key, List<PropertyValue> values, TypeLiteral<T> type) {
+    protected <T> T convertValue(String key, List<PropertyValue> values, TypeLiteral<T> type) {
         if (values != null && !values.isEmpty()) {
             List<PropertyConverter<T>> converters = configurationContext.getPropertyConverters(type);
             ConversionContext context = new ConversionContext.Builder(this, key, type)
@@ -265,12 +265,18 @@ public class DefaultConfiguration implements Configuration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         DefaultConfiguration that = (DefaultConfiguration) o;
 
-        if (!configurationContext.equals(that.configurationContext)) return false;
+        if (!configurationContext.equals(that.configurationContext)) {
+            return false;
+        }
         return configEvaluator.getClass().equals(that.configEvaluator.getClass());
     }
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationContext.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationContext.java
@@ -59,7 +59,7 @@ public class DefaultConfigurationContext implements ConfigurationContext {
     private final ReentrantReadWriteLock propertySourceLock = new ReentrantReadWriteLock();
 
     @SuppressWarnings("unchecked")
-	protected DefaultConfigurationContext(DefaultConfigurationBuilder builder) {
+    protected DefaultConfigurationContext(DefaultConfigurationBuilder builder) {
         this.serviceContext = builder.serviceContext;
         this.metaDataProvider = Objects.requireNonNull(builder.metaDataProvider);
         this.metaDataProvider.init(this);

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationContextBuilder.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationContextBuilder.java
@@ -207,7 +207,7 @@
 //    }
 //
 //    @SuppressWarnings("unchecked")
-//	protected void addCorePropertyConverters() {
+//  protected void addCorePropertyConverters() {
 //        // should be overridden by subclasses.
 //    }
 //

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshot.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshot.java
@@ -121,7 +121,7 @@ public class DefaultConfigurationSnapshot implements ConfigurationSnapshot, Seri
     }
 
     @SuppressWarnings("unchecked")
-	@Override
+    @Override
     public <T> T get(String key, Class<T> type) {
         return snapshot.get(key, type);
     }

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultServiceContext.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/DefaultServiceContext.java
@@ -47,7 +47,7 @@ public final class DefaultServiceContext implements ServiceContext {
      */
     private final Map<Class<?>, Object> singletons = new ConcurrentHashMap<>();
     @SuppressWarnings("rawtypes")
-	private Map<Class, Class> factoryTypes = new ConcurrentHashMap<>();
+    private Map<Class, Class> factoryTypes = new ConcurrentHashMap<>();
 
     @Override
     public <T> T getService(Class<T> serviceType, Supplier<T> supplier) {
@@ -147,13 +147,13 @@ public final class DefaultServiceContext implements ServiceContext {
     @Override
     public <T> List<T> getServices(final Class<T> serviceType, Supplier<List<T>> supplier) {
         @SuppressWarnings("unchecked")
-		List<T> found = (List<T>) servicesLoaded.get(serviceType);
+        List<T> found = (List<T>) servicesLoaded.get(serviceType);
         if (found != null) {
             return found;
         }
         List<T> services = loadServices(serviceType, supplier);
         @SuppressWarnings("unchecked")
-		final List<T> previousServices = List.class.cast(servicesLoaded.putIfAbsent(serviceType, (List<Object>) services));
+        final List<T> previousServices = List.class.cast(servicesLoaded.putIfAbsent(serviceType, (List<Object>) services));
         return previousServices != null ? previousServices : services;
     }
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/EnumConverter.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/EnumConverter.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 
 /**
  * Converter, converting from String to the given enum type.
+ * @param <T> the enum type
  */
 public class EnumConverter<T> implements PropertyConverter<T> {
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PriorityServiceComparator.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PriorityServiceComparator.java
@@ -75,7 +75,7 @@ public class PriorityServiceComparator implements Comparator<Object>, Serializab
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static int getPriority(Class type) {
         int prio = 1;
-		Priority priority = (Priority)type.getAnnotation(Priority.class);
+        Priority priority = (Priority)type.getAnnotation(Priority.class);
         if (priority != null) {
             prio = priority.value();
         }

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertyConverterManager.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertyConverterManager.java
@@ -37,7 +37,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Manager that deals with {@link org.apache.tamaya.spi.PropertyConverter} instances.
@@ -123,7 +122,7 @@ public class PropertyConverterManager {
         Lock writeLock = lock.writeLock();
         try {
             writeLock.lock();
-			List<PropertyConverter<?>> converters = List.class.cast(this.converters.get(targetType));
+            List<PropertyConverter<?>> converters = List.class.cast(this.converters.get(targetType));
             if(converters!=null && converters.contains(converter)){
                 return;
             }
@@ -300,7 +299,7 @@ public class PropertyConverterManager {
      * @return the boxed type, or null.
      */
     @SuppressWarnings("unchecked")
-	private <T> TypeLiteral<T> mapBoxedType(TypeLiteral<T> targetType) {
+    private <T> TypeLiteral<T> mapBoxedType(TypeLiteral<T> targetType) {
         Type parameterType = targetType.getType();
         if (parameterType == int.class) {
             return TypeLiteral.class.cast(TypeLiteral.of(Integer.class));

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertySourceChangeSupport.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertySourceChangeSupport.java
@@ -105,8 +105,7 @@ public final class PropertySourceChangeSupport {
                 version.incrementAndGet();
                 fireListeners(changedKeys);
             }
-        }
-        else{
+        } else {
             if(!properties.equals(this.valueMap)){
                 this.valueMap = properties;
                 version.incrementAndGet();
@@ -128,7 +127,8 @@ public final class PropertySourceChangeSupport {
             if(valueMap != null){
                 if(!valueMap.containsKey(en.getKey())) {
                     result.add(en.getKey()); // added
-                }if(!Objects.equals(valueMap.get(en.getKey()), en.getValue())){
+                }
+                if(!Objects.equals(valueMap.get(en.getKey()), en.getValue())) {
                     result.add(en.getKey()); // changed
                 }
             }else{

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertySourceComparator.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/PropertySourceComparator.java
@@ -23,9 +23,7 @@ import org.apache.tamaya.spi.PropertyValue;
 
 import javax.annotation.Priority;
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.util.Comparator;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BasePropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BasePropertySource.java
@@ -173,8 +173,12 @@ public abstract class BasePropertySource implements PropertySource{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BasePropertySource that = (BasePropertySource) o;
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BuildablePropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BuildablePropertySource.java
@@ -55,8 +55,12 @@ public class BuildablePropertySource implements PropertySource{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BuildablePropertySource that = (BuildablePropertySource) o;
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BuildablePropertySourceProvider.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/BuildablePropertySourceProvider.java
@@ -37,8 +37,12 @@ public class BuildablePropertySourceProvider implements PropertySourceProvider{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BuildablePropertySourceProvider that = (BuildablePropertySourceProvider) o;
 

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySource.java
@@ -128,8 +128,12 @@ class WrappedPropertySource implements PropertySource{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof WrappedPropertySource)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WrappedPropertySource)) {
+            return false;
+        }
 
         WrappedPropertySource that = (WrappedPropertySource) o;
 

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,6 @@
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <configLocation>buildconfigurations/src/main/resources/checkstyle/style.xml</configLocation>
-                        <failOnViolation>false</failOnViolation>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
The enforces checkstyle rules for the main Tamaya code.

In general, the existing checkstyle rules remain the same and the code has been adjusted to align to that. The only changes made to the checkstyle rules was to add some additional exclusions to the `AvoidStarImport` rule; the following packages were added: 
 
* java.lang.annotation
* org.osgi.framework
* org.apache.tamaya
* org.apache.tamaya.spi
* org.apache.tamaya.core.internal.converters

The `OSGIServiceLoader` was almost entirely replaced because tabs were replaced with spaces. The code there stays the same, but one change was made (to align with another checkstyle rule):

This:

```java
for (Bundle bundle : context.getBundles()) {
	switch (bundle.getState()) {
	case Bundle.ACTIVE:
		checkAndLoadBundle(bundle);
	}
}
```

was changed to this (checkstyle doesn't allow `switch` statements without a `default` branch):
```java
for (Bundle bundle : context.getBundles()) {
     if (bundle.getState() == Bundle.ACTIVE) {
         checkAndLoadBundle(bundle);
     }
}
```
