### PR TITLE
TAMAYA-379: Tighten checkstyle rules for main codebase

### DIFF
--- a/buildconfigurations/src/main/resources/checkstyle/style.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/style.xml
@@ -53,33 +53,14 @@ under the License.
                 </module>
         -->
 
-        <module name="ConstantName">
-            <!-- Normal rules, except that:
-               -  * any name can start with an underscore.
-               -  * "log" is allowed; this is a traditional name for log objects
-               -  * names ending with "ThreadLocal" are allowed so that threadlocal vars don't have to be
-               -    all-caps. They are static final, but are not really constants. Yes, type prefixes
-               -    on variable names sucks ("hungarian notation") but checkstyle doesn't allow
-               -    name rules to vary by the type of the constant, and no other alternative seems
-               -    any better.
-               -->
-            <property name="format"
-                      value="^_?((log)|(logger)|([a-z][a-zA-Z]*ThreadLocal)|([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$"/>
-        </module>
-
+        <module name="ConstantName"/>
         <module name="LocalVariableName"/>
-        <module name="MethodName">
-            <property name="format"
-                      value="^_?[a-z][a-zA-Z0-9]*$"/>
-        </module>
+        <module name="MethodName"/>
         <module name="PackageName"/>
         <module name="LocalFinalVariableName"/>
         <module name="ParameterName"/>
         <module name="StaticVariableName"/>
-        <module name="TypeName">
-            <property name="format"
-                      value="^_?[A-Z][a-zA-Z0-9]*$"/>
-        </module>
+        <module name="TypeName"/>
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/BannerManager.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/BannerManager.java
@@ -105,7 +105,7 @@ class BannerManager {
  * An abstract Tamaya banner printer.
  */
 abstract class AbstractBannerPrinter implements BannerPrinter {
-    private static final Logger log = Logger.getLogger(AbstractBannerPrinter.class.getName());
+    private static final Logger LOG = Logger.getLogger(AbstractBannerPrinter.class.getName());
 
     @Override
     public void outputBanner() {
@@ -117,7 +117,7 @@ abstract class AbstractBannerPrinter implements BannerPrinter {
                 outputSingleLine(line);
             }
         } catch (Exception e) {
-            log.log(Level.WARNING, "Failed to output the banner of tamaya.", e);
+            LOG.log(Level.WARNING, "Failed to output the banner of tamaya.", e);
         }
     }
 
@@ -150,11 +150,11 @@ class SilentBannerPrinter implements BannerPrinter {
  * Logs the banner via JUL at level {@link java.util.logging.Level#INFO}.
  */
 class LoggingBannerPrinter extends AbstractBannerPrinter {
-    private static final Logger log = Logger.getLogger(LoggingBannerPrinter.class.getName());
+    private static final Logger LOG = Logger.getLogger(LoggingBannerPrinter.class.getName());
 
     @Override
     void outputSingleLine(String line) {
-        log.log(Level.INFO, line);
+        LOG.log(Level.INFO, line);
     }
 }
 

--- a/code/core/src/main/java/org/apache/tamaya/core/internal/OSGIServiceLoader.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/internal/OSGIServiceLoader.java
@@ -45,7 +45,7 @@ import org.osgi.framework.ServiceRegistration;
 @SuppressWarnings("rawtypes")
 public class OSGIServiceLoader implements BundleListener {
     // Provide logging
-    private static final Logger log = Logger.getLogger(OSGIServiceLoader.class.getName());
+    private static final Logger LOG = Logger.getLogger(OSGIServiceLoader.class.getName());
     private static final String META_INF_SERVICES = "META-INF/services/";
 
     private BundleContext context;
@@ -90,7 +90,7 @@ public class OSGIServiceLoader implements BundleListener {
         }
         synchronized (resourceBundles) {
             resourceBundles.remove(bundle);
-            log.fine("Unregistered ServiceLoader bundle: " + bundle.getSymbolicName());
+            LOG.fine("Unregistered ServiceLoader bundle: " + bundle.getSymbolicName());
         }
         Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
         while (entryPaths.hasMoreElements()) {
@@ -107,7 +107,7 @@ public class OSGIServiceLoader implements BundleListener {
         }
         synchronized (resourceBundles) {
             resourceBundles.add(bundle);
-            log.info("Registered ServiceLoader bundle: " + bundle.getSymbolicName());
+            LOG.info("Registered ServiceLoader bundle: " + bundle.getSymbolicName());
         }
         Enumeration<String> entryPaths = bundle.getEntryPaths(META_INF_SERVICES);
         while (entryPaths.hasMoreElements()) {
@@ -128,7 +128,7 @@ public class OSGIServiceLoader implements BundleListener {
             Class<?> serviceClass = bundle.loadClass(serviceName);
             URL child = bundle.getEntry(entryPath);
             InputStream inStream = child.openStream();
-            log.info("Loading Services " + serviceClass.getName() + " from bundle...: " + bundle.getSymbolicName());
+            LOG.info("Loading Services " + serviceClass.getName() + " from bundle...: " + bundle.getSymbolicName());
             try (BufferedReader br = new BufferedReader(new InputStreamReader(inStream, "UTF-8"))) {
                 String implClassName = br.readLine();
                 while (implClassName != null) {
@@ -142,14 +142,14 @@ public class OSGIServiceLoader implements BundleListener {
                     if (implClassName.length() > 0) {
                         try {
                             // Load the service class
-                            log.fine("Loading Class " + implClassName + " from bundle...: " + bundle.getSymbolicName());
+                            LOG.fine("Loading Class " + implClassName + " from bundle...: " + bundle.getSymbolicName());
                             Class<?> implClass = bundle.loadClass(implClassName);
                             if (!serviceClass.isAssignableFrom(implClass)) {
-                                log.warning("Configured service: " + implClassName + " is not assignable to "
+                                LOG.warning("Configured service: " + implClassName + " is not assignable to "
                                         + serviceClass.getName());
                                 continue;
                             }
-                            log.info("Loaded Service Factory (" + serviceName + "): " + implClassName);
+                            LOG.info("Loaded Service Factory (" + serviceName + "): " + implClassName);
                             // Provide service properties
                             Hashtable<String, String> props = new Hashtable<>();
                             props.put(Constants.VERSION_ATTRIBUTE, bundle.getVersion().toString());
@@ -163,11 +163,11 @@ public class OSGIServiceLoader implements BundleListener {
                             JDKUtilServiceFactory factory = new JDKUtilServiceFactory(implClass);
                             BundleContext bundleContext = bundle.getBundleContext();
                             bundleContext.registerService(serviceName, factory, props);
-                            log.info("Registered Tamaya service class: " + implClassName + "(" + serviceName + ")");
+                            LOG.info("Registered Tamaya service class: " + implClassName + "(" + serviceName + ")");
                         } catch (Exception e) {
-                            log.log(Level.SEVERE, "Failed to load service: " + implClassName, e);
+                            LOG.log(Level.SEVERE, "Failed to load service: " + implClassName, e);
                         } catch (NoClassDefFoundError err) {
-                            log.log(Level.SEVERE, "Failed to load service: " + implClassName, err);
+                            LOG.log(Level.SEVERE, "Failed to load service: " + implClassName, err);
                         }
                     }
                     implClassName = br.readLine();
@@ -176,7 +176,7 @@ public class OSGIServiceLoader implements BundleListener {
         } catch (RuntimeException rte) {
             throw rte;
         } catch (Exception e) {
-            log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
+            LOG.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
         }
     }
 
@@ -203,12 +203,12 @@ public class OSGIServiceLoader implements BundleListener {
                 }
                 implClassName = implClassName.trim();
                 if (implClassName.length() > 0) {
-                    log.fine("Unloading Service (" + serviceName + "): " + implClassName);
+                    LOG.fine("Unloading Service (" + serviceName + "): " + implClassName);
                     try {
                         // Load the service class
                         Class<?> implClass = bundle.loadClass(implClassName);
                         if (!serviceClass.isAssignableFrom(implClass)) {
-                            log.warning("Configured service: " + implClassName + " is not assignable to "
+                            LOG.warning("Configured service: " + implClassName + " is not assignable to "
                                     + serviceClass.getName());
                             continue;
                         }
@@ -217,9 +217,9 @@ public class OSGIServiceLoader implements BundleListener {
                             bundle.getBundleContext().ungetService(ref);
                         }
                     } catch (Exception e) {
-                        log.log(Level.SEVERE, "Failed to unload service: " + implClassName, e);
+                        LOG.log(Level.SEVERE, "Failed to unload service: " + implClassName, e);
                     } catch (NoClassDefFoundError err) {
-                        log.log(Level.SEVERE, "Failed to unload service: " + implClassName, err);
+                        LOG.log(Level.SEVERE, "Failed to unload service: " + implClassName, err);
                     }
                 }
                 implClassName = br.readLine();
@@ -228,7 +228,7 @@ public class OSGIServiceLoader implements BundleListener {
         } catch (RuntimeException rte) {
             throw rte;
         } catch (Exception e) {
-            log.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
+            LOG.log(Level.SEVERE, "Failed to read services from: " + entryPath, e);
         }
     }
 
@@ -245,7 +245,7 @@ public class OSGIServiceLoader implements BundleListener {
         @Override
         public Object getService(Bundle bundle, ServiceRegistration registration) {
             try {
-                log.fine("Creating Service...:" + serviceClass.getName());
+                LOG.fine("Creating Service...:" + serviceClass.getName());
                 return serviceClass.getConstructor().newInstance();
             } catch (Exception ex) {
                 ex.printStackTrace();


### PR DESCRIPTION
This changes the ConstantName, MethodName and TypeName checkstyle rules
such that the default (and standard) Java formatting rules are followed.

By changing the checkstyle configuration in this way, the only required code modification was replacing the constant `log` with `LOG`.