### PR TITLE
TAMAYA-379: Enforce checkstyle rules on the example projects

### DIFF
--- a/examples/01-minimal/pom.xml
+++ b/examples/01-minimal/pom.xml
@@ -54,5 +54,13 @@ under the License.
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/02-custom-property-source/pom.xml
+++ b/examples/02-custom-property-source/pom.xml
@@ -51,5 +51,13 @@ under the License.
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/02-custom-property-source/src/main/java/org/apache/tamaya/examples/custompropertysource/SimplePropertySource.java
+++ b/examples/02-custom-property-source/src/main/java/org/apache/tamaya/examples/custompropertysource/SimplePropertySource.java
@@ -29,6 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * A simple PropertySource class.
+ */
 public class SimplePropertySource extends BasePropertySource {
 
     public static final String CONFIG_PROPERTIES_LOCATION = "META-INF/MyOtherConfigProperties.properties";
@@ -38,7 +41,7 @@ public class SimplePropertySource extends BasePropertySource {
         URL url = ClassLoader.getSystemClassLoader().getResource(CONFIG_PROPERTIES_LOCATION);
         Properties properties = new Properties();
 
-        try(InputStream is = url.openStream()){
+        try(InputStream is = url.openStream()) {
             properties.load(is);
 
             for(Map.Entry en: properties.entrySet()){
@@ -46,8 +49,7 @@ public class SimplePropertySource extends BasePropertySource {
                         PropertyValue.createValue(en.getKey().toString(), en.getValue().toString())
                         .setMeta("source", getName()));
             }
-        }
-        finally{
+        } finally {
             props = Collections.unmodifiableMap(props);
         }
     }

--- a/examples/02-custom-property-source/src/main/java/org/apache/tamaya/examples/custompropertysource/SimplePropertySourceProvider.java
+++ b/examples/02-custom-property-source/src/main/java/org/apache/tamaya/examples/custompropertysource/SimplePropertySourceProvider.java
@@ -28,6 +28,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * A simple PropertySource provider class.
+ */
 public class SimplePropertySourceProvider implements PropertySourceProvider {
     private static final String[] RESOURCES = {
         "cfgOther/a.properties", "cfgOther/b.properties", "cfgOther/c.properties"

--- a/examples/11-distributed/pom.xml
+++ b/examples/11-distributed/pom.xml
@@ -104,6 +104,11 @@
                     <showDeprecation>${maven.compile.deprecation}</showDeprecation>
                 </configuration>
             </plugin>
+
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This enforces checkstyle rules on the example projects and makes a few
minor adjustments to bring the custom-property-source project in line
with the formatting rules.