### PR TITLE
TAMAYA-379: Apply checkstyle to test code

### DIFF
--- a/buildconfigurations/src/main/resources/checkstyle/style.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/style.xml
@@ -20,6 +20,12 @@ under the License.
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
+
+    <!-- Suppression -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${checkstyle.suppressions.file}"/>
+    </module>
+
     <module name="SuppressionCommentFilter"/>
 
     <!-- Checks for Size Violations.                    -->

--- a/buildconfigurations/src/main/resources/checkstyle/suppressions.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/suppressions.xml
@@ -1,0 +1,27 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE suppressions PUBLIC
+     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+  <suppress checks="EmptyStatement" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocType" files="src[/\\]test[/\\]java"/>
+  <suppress checks="MethodLength" files="src[/\\]test[/\\]java"/>
+  <suppress checks="MethodName" files="src[/\\]test[/\\]java"/>
+</suppressions>

--- a/code/api/src/test/java/org/apache/tamaya/ConfigExceptionTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigExceptionTest.java
@@ -20,7 +20,7 @@ package org.apache.tamaya;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests instantiating {@link ConfigException}.

--- a/code/api/src/test/java/org/apache/tamaya/ConfigurationProviderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigurationProviderTest.java
@@ -20,8 +20,9 @@ package org.apache.tamaya;
 
 import org.apache.tamaya.spi.ConfigurationBuilder;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
 import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/api/src/test/java/org/apache/tamaya/ConfigurationTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/ConfigurationTest.java
@@ -32,7 +32,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Test class that tests the default methods implemented on

--- a/code/api/src/test/java/org/apache/tamaya/InvocationRecorder.java
+++ b/code/api/src/test/java/org/apache/tamaya/InvocationRecorder.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tamaya;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;

--- a/code/api/src/test/java/org/apache/tamaya/TestConfiguration.java
+++ b/code/api/src/test/java/org/apache/tamaya/TestConfiguration.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.apache.tamaya.spi.ConfigurationProviderSpi;
 import org.apache.tamaya.spi.ServiceContext;
 import org.mockito.Mockito;
-import org.mockito.internal.matchers.Any;
 
 /**
  * Test Configuration class, that is used to testdata the default methods

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationProviderSpiTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConfigurationProviderSpiTest.java
@@ -20,7 +20,8 @@ package org.apache.tamaya.spi;
 
 import org.apache.tamaya.TestConfigurationProvider;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigurationProviderSpiTest {
     

--- a/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ConversionContextTest.java
@@ -56,8 +56,8 @@ public class ConversionContextTest {
     public void getSetAnnotatedElement() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("getAnnotatedElement", TypeLiteral.of(List.class)).build();
         assertThat(ctx.getAnnotatedElement()).isNull();
-        ctx = new ConversionContext.Builder(TypeLiteral.of(List.class)).setAnnotatedElement(MyAnnotatedElement).build();
-        assertThat(ctx.getAnnotatedElement()).isEqualTo(MyAnnotatedElement);
+        ctx = new ConversionContext.Builder(TypeLiteral.of(List.class)).setAnnotatedElement(MY_ANNOTATED_ELEMENT).build();
+        assertThat(ctx.getAnnotatedElement()).isEqualTo(MY_ANNOTATED_ELEMENT);
     }
 
     @Test
@@ -95,7 +95,9 @@ public class ConversionContextTest {
     public void testToString() throws Exception {
         ConversionContext ctx = new ConversionContext.Builder("toString", TypeLiteral.of(List.class))
                 .addSupportedFormats(MyConverter.class, "0.0.0.0/nnn", "x.x.x.x/yyy").build();
-        assertThat(ctx.toString()).isEqualTo("ConversionContext{configuration=null, key='toString', targetType=TypeLiteral{type=interface java.util.List}, annotatedElement=null, supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]}");
+        assertThat(ctx.toString()).isEqualTo("ConversionContext{configuration=null, key='toString', "
+                + "targetType=TypeLiteral{type=interface java.util.List}, "
+                + "annotatedElement=null, supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]}");
     }
 
     @Test
@@ -143,7 +145,7 @@ public class ConversionContextTest {
                 "supportedFormats=[0.0.0.0/nnn (MyConverter), x.x.x.x/yyy (MyConverter)]", "annotatedElement", "key='toString'", "Builder");
     }
 
-    private static final AnnotatedElement MyAnnotatedElement = new AnnotatedElement() {
+    private static final AnnotatedElement MY_ANNOTATED_ELEMENT = new AnnotatedElement() {
         @Override
         public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
             throw new UnsupportedOperationException("Not supported yet.");

--- a/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/FilterContextTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.tamaya.spi;
 
-import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.*;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -85,7 +83,7 @@ public class FilterContextTest {
     }
 
     @SuppressWarnings("unchecked")
-	@Test(expected = NullPointerException.class)
+    @Test(expected = NullPointerException.class)
     public void constructorRequiresNonNullPropertyValueThreeParameterVariant() {
         new FilterContext(null, Collections.EMPTY_MAP, ConfigurationContext.EMPTY);
     }

--- a/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/PropertySourceProviderTest.java
@@ -19,7 +19,8 @@
 package org.apache.tamaya.spi;
 
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertySourceProviderTest {
     

--- a/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextManagerTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextManagerTest.java
@@ -27,7 +27,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Additional tests for {@link ServiceContextManager}, created by atsticks on 20.08.16.

--- a/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
+++ b/code/api/src/test/java/org/apache/tamaya/spi/ServiceContextTest.java
@@ -20,8 +20,6 @@ package org.apache.tamaya.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-import java.net.URL;
 import java.util.*;
 import java.util.function.Supplier;
 

--- a/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/ConfigurationBuilderTest.java
@@ -21,13 +21,17 @@ package org.apache.tamaya.core;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.core.internal.CoreConfigurationBuilder;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationBuilder;
+import org.apache.tamaya.spi.ConfigurationContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyFilter;
+import org.apache.tamaya.spi.PropertySource;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Comparator;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link ConfigurationBuilder} by atsticks on 06.09.16.
@@ -175,7 +179,7 @@ public class ConfigurationBuilderTest {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void addPropertyConverters_Array() throws Exception {
-		PropertyConverter converter = (value, ctx) -> value.toLowerCase();
+        PropertyConverter converter = (value, ctx) -> value.toLowerCase();
         ConfigurationBuilder b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
@@ -191,7 +195,7 @@ public class ConfigurationBuilderTest {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void addPropertyConverters_Collection() throws Exception {
-		PropertyConverter converter = (value, ctx) -> value.toLowerCase();
+        PropertyConverter converter = (value, ctx) -> value.toLowerCase();
         ConfigurationBuilder b = Configuration.createConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class),
                         Arrays.<PropertyConverter<Object>>asList(new PropertyConverter[]{converter}));
@@ -225,7 +229,7 @@ public class ConfigurationBuilderTest {
 
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-	@Test
+    @Test
     public void removePropertyConverters_Collection() throws Exception {
         PropertyConverter converter = (value, ctx) -> value.toLowerCase();
         ConfigurationBuilder b = Configuration.createConfigurationBuilder()

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationBuilderTest.java
@@ -28,10 +28,15 @@ import java.util.*;
 
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationBuilder;
+import org.apache.tamaya.spi.ConfigurationContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyFilter;
+import org.apache.tamaya.spi.PropertySource;
+import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link CoreConfigurationBuilder} by atsticks on 06.09.16.
@@ -118,8 +123,8 @@ public class CoreConfigurationBuilderTest {
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void addPropertyConverter() throws Exception {
-		PropertyConverter converter = (value, ctx) -> value.toLowerCase();
-		ConfigurationBuilder b = new CoreConfigurationBuilder()
+        PropertyConverter converter = (value, ctx) -> value.toLowerCase();
+        ConfigurationBuilder b = new CoreConfigurationBuilder()
                 .addPropertyConverters(TypeLiteral.of(String.class), converter);
         Configuration cfg = b.build();
         ConfigurationContext ctx = cfg.getContext();

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.core.internal;
 import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 11.09.16.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
@@ -21,10 +21,14 @@ package org.apache.tamaya.core.internal;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.core.testdata.TestPropertyDefaultSource;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConversionContext;
+import org.apache.tamaya.spi.FilterContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyFilter;
+import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Simple tests for {@link CoreConfiguration} by atsticks on 16.08.16.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/DefaultJavaConfigurationTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.core.internal;
 import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultJavaConfigurationTest {
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceComparatorTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceComparatorTest.java
@@ -20,9 +20,10 @@ package org.apache.tamaya.core.internal;
 
 import javax.annotation.Priority;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.ServiceReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceContextTest.java
@@ -22,15 +22,13 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/OSGIServiceLoaderTest.java
@@ -20,10 +20,11 @@ package org.apache.tamaya.core.internal;
 
 import java.util.Set;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigDecimalConverterTest.java
@@ -33,107 +33,107 @@ import static org.mockito.Mockito.verify;
  */
 public class BigDecimalConverterTest {
 
-	/**
-	 * Test conversion. The createValue are provided by
-	 * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testConvert_BigDecimal_Decimal() throws Exception {
-		Configuration config = Configuration.current();
-		BigDecimal valueRead = config.get("tests.converter.bd.decimal", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(valueRead).isEqualTo(new BigDecimal(101));
-	}
+    /**
+     * Test conversion. The createValue are provided by
+     * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvert_BigDecimal_Decimal() throws Exception {
+        Configuration config = Configuration.current();
+        BigDecimal valueRead = config.get("tests.converter.bd.decimal", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isEqualTo(new BigDecimal(101));
+    }
 
-	/**
-	 * Test conversion. The createValue are provided by
-	 * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testConvert_BigDecimal_Hex() throws Exception {
-		Configuration config = Configuration.current();
-		BigDecimal valueRead = config.get("tests.converter.bd.hex.lowerX", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(valueRead).isEqualTo(new BigDecimal("47"));
-		valueRead = config.get("tests.converter.bd.hex.upperX", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(valueRead).isEqualTo(new BigDecimal("63"));
-		valueRead = config.get("tests.converter.bd.hex.negLowerX", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(valueRead).isEqualTo(new BigDecimal("-47"));
-		valueRead = config.get("tests.converter.bd.hex.negUpperX", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(valueRead).isEqualTo(new BigDecimal("-63"));
-	}
+    /**
+     * Test conversion. The createValue are provided by
+     * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvert_BigDecimal_Hex() throws Exception {
+        Configuration config = Configuration.current();
+        BigDecimal valueRead = config.get("tests.converter.bd.hex.lowerX", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isEqualTo(new BigDecimal("47"));
+        valueRead = config.get("tests.converter.bd.hex.upperX", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isEqualTo(new BigDecimal("63"));
+        valueRead = config.get("tests.converter.bd.hex.negLowerX", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isEqualTo(new BigDecimal("-47"));
+        valueRead = config.get("tests.converter.bd.hex.negUpperX", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(valueRead).isEqualTo(new BigDecimal("-63"));
+    }
 
-	/**
-	 * Test conversion. The createValue are provided by
-	 * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testConvert_NotPresent() throws Exception {
-		Configuration config = Configuration.current();
-		BigDecimal valueRead = config.get("tests.converter.bd.foo", BigDecimal.class);
-		assertThat(valueRead).isNull();
-	}
+    /**
+     * Test conversion. The createValue are provided by
+     * {@link org.apache.tamaya.core.internal.converters.ConverterTestsPropertySource}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvert_NotPresent() throws Exception {
+        Configuration config = Configuration.current();
+        BigDecimal valueRead = config.get("tests.converter.bd.foo", BigDecimal.class);
+        assertThat(valueRead).isNull();
+    }
 
-	/**
-	 * Test conversion. The createValue are provided by
-	 * {@link ConverterTestsPropertySource}.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testConvert_BigDecimal_BigValue() throws Exception {
-		Configuration config = Configuration.current();
-		BigDecimal valueRead = config.get("tests.converter.bd.big", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"))
+    /**
+     * Test conversion. The createValue are provided by
+     * {@link ConverterTestsPropertySource}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvert_BigDecimal_BigValue() throws Exception {
+        Configuration config = Configuration.current();
+        BigDecimal valueRead = config.get("tests.converter.bd.big", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(new BigDecimal("101666666666666662333337263723628763821638923628193612983618293628763"))
                         .isEqualTo(valueRead);
-	}
+    }
 
-	/**
-	 * Test conversion. The createValue are provided by
-	 * {@link ConverterTestsPropertySource}.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testConvert_BigDecimal_BigFloatValue() throws Exception {
-		Configuration config = Configuration.current();
-		BigDecimal valueRead = config.get("tests.converter.bd.bigFloat", BigDecimal.class);
-		assertThat(valueRead).isNotNull();
-		assertThat(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372"
-				+ "63723628763821638923628193612983618293628763"))
+    /**
+     * Test conversion. The createValue are provided by
+     * {@link ConverterTestsPropertySource}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConvert_BigDecimal_BigFloatValue() throws Exception {
+        Configuration config = Configuration.current();
+        BigDecimal valueRead = config.get("tests.converter.bd.bigFloat", BigDecimal.class);
+        assertThat(valueRead).isNotNull();
+        assertThat(new BigDecimal("1016666666666666623333372637236287638216389293628763.1016666666666666623333372"
+                + "63723628763821638923628193612983618293628763"))
                         .isEqualTo(valueRead);
-	}
+    }
 
-	@Test
-	public void converterHandlesNullValueCorrectly() throws Exception {
-		ConversionContext context = mock(ConversionContext.class);
+    @Test
+    public void converterHandlesNullValueCorrectly() throws Exception {
+        ConversionContext context = mock(ConversionContext.class);
 
-		BigDecimalConverter converter = new BigDecimalConverter();
-		BigDecimal value = converter.convert("", context);
+        BigDecimalConverter converter = new BigDecimalConverter();
+        BigDecimal value = converter.convert("", context);
 
-		assertThat(value).isNull();
-	}
+        assertThat(value).isNull();
+    }
 
-	@Test
-	public void callToConvertAddsMoreSupportedFormatsToTheContext() throws Exception {
-		ConversionContext context = mock(ConversionContext.class);
+    @Test
+    public void callToConvertAddsMoreSupportedFormatsToTheContext() throws Exception {
+        ConversionContext context = mock(ConversionContext.class);
 
-		BigDecimalConverter converter = new BigDecimalConverter();
-		BigDecimal value = converter.convert("", context);
+        BigDecimalConverter converter = new BigDecimalConverter();
+        BigDecimal value = converter.convert("", context);
 
-		assertThat(value).isNull();
-		verify(context).addSupportedFormats(BigDecimalConverter.class, "<bigDecimal> -> new BigDecimal(String)");
-	}
+        assertThat(value).isNull();
+        verify(context).addSupportedFormats(BigDecimalConverter.class, "<bigDecimal> -> new BigDecimal(String)");
+    }
 
     @Test
     public void testEquality() throws Exception {

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/BigIntegerConverterTest.java
@@ -24,7 +24,8 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ByteConverterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the default converter for bytes.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/CharConverterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests conversion of the {@link CharConverter}.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ClassConverterTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests conversion of the {@link ClassConverter}.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConvertQueryTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConvertQueryTest.java
@@ -21,7 +21,8 @@ package org.apache.tamaya.core.internal.converters;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConverterTestsPropertySource.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ConverterTestsPropertySource.java
@@ -289,9 +289,9 @@ public class ConverterTestsPropertySource implements PropertySource {
                 return PropertyValue.createValue(key, "-0X0107");
             case "tests.converter.bd.invalid":
                 return PropertyValue.createValue(key, "invalid");
-
+            default:
+                return null;
         }
-        return null;
     }
 
     @Override

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DoubleConverterTest.java
@@ -22,9 +22,10 @@ import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Tests the default converter for doubles.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/DurationConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.Duration;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/FileConverterTest.java
@@ -23,7 +23,8 @@ import java.net.URL;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/InstantConverterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
+import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +26,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.time.Instant;
-import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/IntegerConverterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the default converter for Integers.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.LocalDate;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalDateTimeConverterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
+import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +26,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.time.LocalDateTime;
-import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LocalTimeConverterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
+import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +26,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.time.LocalTime;
-import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/LongConverterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the default converter for Longs.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/NumberConverterTest.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
+import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.Configuration;
+import org.apache.tamaya.TypeLiteral;
+import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import org.apache.tamaya.ConfigException;
-import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.ConversionContext;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Tests the default converter for Number.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetDateTimeConverterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
+import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,9 +26,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.time.OffsetDateTime;
-import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OffsetTimeConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.OffsetTime;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/OptionalConverterTest.java
@@ -18,20 +18,17 @@
  */
 package org.apache.tamaya.core.internal.converters;
 
-import java.util.List;
 import org.apache.tamaya.ConfigException;
 import org.apache.tamaya.Configuration;
-import org.apache.tamaya.spi.FilterContext;
-import org.junit.Test;
-
-import java.util.Optional;
-
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
-import org.mockito.Mock;
+import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.*;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalConverterTest {
 

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/PathConverterTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.tamaya.TypeLiteral;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsti on 02.10.2017.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/ShortConverterTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the default converter for Shorts.

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/converters/SupplierConverterTest.java
@@ -26,9 +26,10 @@ import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConversionContext;
 import org.apache.tamaya.spi.PropertyConverter;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Matchers.any;
 import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 
 /**
  *

--- a/code/core/src/test/java/org/apache/tamaya/core/propertysource/BasePropertySourceTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/propertysource/BasePropertySourceTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Deprecated
 public class BasePropertySourceTest {

--- a/code/core/src/test/java/org/apache/tamaya/core/testdata/TestRemovingPropertyFilter.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/testdata/TestRemovingPropertyFilter.java
@@ -32,10 +32,9 @@ import javax.annotation.Priority;
 public class TestRemovingPropertyFilter implements PropertyFilter{
     @Override
     public PropertyValue filterProperty(PropertyValue valueToBeFiltered, FilterContext context) {
-        if("name5".equals(valueToBeFiltered.getKey())){
+        if ("name5".equals(valueToBeFiltered.getKey())) {
             return null;
-        }
-        else if("name3".equals(valueToBeFiltered.getKey())){
+        } else if("name3".equals(valueToBeFiltered.getKey())) {
             return valueToBeFiltered
                     .setValue("Mapped to name: " + Configuration.current().get("name"));
         }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceProviderTest.java
@@ -24,7 +24,7 @@ import org.apache.tamaya.spisupport.propertysource.BuildablePropertySource;
 import org.apache.tamaya.spisupport.propertysource.BuildablePropertySourceProvider;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildablePropertySourceProviderTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/BuildablePropertySourceTest.java
@@ -26,7 +26,7 @@ import org.apache.tamaya.spi.PropertyValue;
 import org.apache.tamaya.spisupport.propertysource.BuildablePropertySource;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildablePropertySourceTest {
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigValueEvaluatorTest.java
@@ -22,7 +22,8 @@ import java.util.Map;
 import org.apache.tamaya.Configuration;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
@@ -24,10 +24,14 @@ import org.apache.tamaya.Configuration;
 import org.apache.tamaya.ConfigurationProvider;
 import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConfigurationBuilder;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyFilter;
+import org.apache.tamaya.spi.PropertySource;
+import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link  DefaultConfigurationBuilder} by atsticks on 06.09.16.

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationContextTest.java
@@ -20,13 +20,12 @@ package org.apache.tamaya.spisupport;
 
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.ServiceContext;
-import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationTest.java
@@ -19,13 +19,14 @@
 package org.apache.tamaya.spisupport;
 
 import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationContext;
+import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultConfigurationTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
@@ -19,10 +19,8 @@
 package org.apache.tamaya.spisupport;
 
 import org.apache.tamaya.spi.ConfigurationContext;
-import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultPropertySourceSnapshotTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultPropertySourceSnapshotTest.java
@@ -25,24 +25,25 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link DefaultPropertySourceSnapshot}.
  */
 public class DefaultPropertySourceSnapshotTest {
 
-    private static final PropertySource myPS = new SystemPropertySource();
+    private static final PropertySource MY_PS = new SystemPropertySource();
 
     @Test
     public void testOf() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
         assertThat(ps).isNotNull();
     }
 
     @Test
     public void testGetName() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
         String name = ps.getName();
         assertThat(name).isNotNull();
         assertThat(name).isEqualTo(ps.getName());
@@ -50,35 +51,35 @@ public class DefaultPropertySourceSnapshotTest {
 
     @Test
     public void testGetOrdinal() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
-        assertThat(PropertySourceComparator.getOrdinal(myPS))
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
+        assertThat(PropertySourceComparator.getOrdinal(MY_PS))
             .isEqualTo(PropertySourceComparator.getOrdinal(ps));
     }
 
     @Test
     public void testGet() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
         assertThat(ps).isNotNull();
-        for (Map.Entry<String, PropertyValue> e : myPS.getProperties().entrySet()) {
+        for (Map.Entry<String, PropertyValue> e : MY_PS.getProperties().entrySet()) {
             assertThat(ps.get(e.getKey()).getValue()).isEqualTo(e.getValue().getValue());
         }
     }
 
     @Test
     public void testGetProperties() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
         assertThat(ps).isNotNull();
         assertThat(ps.getProperties()).isNotNull();
         assertThat(ps.getProperties()).isNotEmpty();
-        for(Map.Entry en:myPS.getProperties().entrySet()){
+        for(Map.Entry en:MY_PS.getProperties().entrySet()){
             assertThat(en.getValue()).isEqualTo(ps.get((String)en.getKey()));
         }
     }
 
     @Test
     public void testEquals() throws Exception {
-        PropertySource ps1 = DefaultPropertySourceSnapshot.of(myPS);
-        PropertySource ps2 = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps1 = DefaultPropertySourceSnapshot.of(MY_PS);
+        PropertySource ps2 = DefaultPropertySourceSnapshot.of(MY_PS);
         assertThat(ps1.getName()).isEqualTo(ps2.getName());
         assertThat(ps1.getProperties()).hasSize(ps2.getProperties().size());
     }
@@ -87,8 +88,8 @@ public class DefaultPropertySourceSnapshotTest {
     public void testHashCode() throws Exception {
         boolean alwaysDifferent = true;
         for(int i=0;i<10;i++){
-            PropertySource ps1 = DefaultPropertySourceSnapshot.of(myPS);
-            PropertySource ps2 = DefaultPropertySourceSnapshot.of(myPS);
+            PropertySource ps1 = DefaultPropertySourceSnapshot.of(MY_PS);
+            PropertySource ps2 = DefaultPropertySourceSnapshot.of(MY_PS);
             // sometimes not same, because frozenAt in ms maybe different
             if(ps1.hashCode()==ps2.hashCode()){
                 alwaysDifferent=false;
@@ -102,10 +103,10 @@ public class DefaultPropertySourceSnapshotTest {
 
     @Test
     public void testToString() throws Exception {
-        PropertySource ps = DefaultPropertySourceSnapshot.of(myPS);
+        PropertySource ps = DefaultPropertySourceSnapshot.of(MY_PS);
         String toString = ps.toString();
         assertThat(toString).isNotNull();
         assertThat(toString).contains("FrozenPropertySource");
-        assertThat(toString).contains(myPS.getName());
+        assertThat(toString).contains(MY_PS.getName());
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultServiceContextTest.java
@@ -26,7 +26,8 @@ import javax.annotation.Priority;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultServiceContextTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/EnumConverterTest.java
@@ -37,7 +37,7 @@ public class EnumConverterTest {
     private final ConversionContext DUMMY_CONTEXT = new ConversionContext.Builder("someKey", TypeLiteral.of(Enum.class))
             .build();
 
-    private enum TEST_ENUM {
+    private enum TestEnum {
         A, B, C, D
     };
 
@@ -73,7 +73,7 @@ public class EnumConverterTest {
     public void testEqualsAndHash() {
         EnumConverter converter1 = new EnumConverter<>(RoundingMode.class);
         EnumConverter converter2 = new EnumConverter<>(RoundingMode.class);
-        EnumConverter converter3 = new EnumConverter<>(TEST_ENUM.class);
+        EnumConverter converter3 = new EnumConverter<>(TestEnum.class);
 
         assertThat(converter1).isEqualTo(converter1);
         assertThat(converter1).isNotEqualTo(null);

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/MockedConfigurationContext.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/MockedConfigurationContext.java
@@ -21,7 +21,12 @@ package org.apache.tamaya.spisupport;
 import java.util.*;
 
 import org.apache.tamaya.TypeLiteral;
-import org.apache.tamaya.spi.*;
+import org.apache.tamaya.spi.ConfigurationContext;
+import org.apache.tamaya.spi.PropertyConverter;
+import org.apache.tamaya.spi.PropertyFilter;
+import org.apache.tamaya.spi.PropertySource;
+import org.apache.tamaya.spi.ServiceContext;
+import org.apache.tamaya.spi.ServiceContextManager;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PriorityServiceComparatorTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PriorityServiceComparatorTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import javax.annotation.Priority;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by atsticks on 12.09.16.

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertyConverterManagerTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertyConverterManagerTest.java
@@ -27,10 +27,9 @@ import org.apache.tamaya.spi.ServiceContext;
 import org.apache.tamaya.spi.ServiceContextManager;
 import org.junit.Test;
 
-import java.math.RoundingMode;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertyConverterManagerTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
@@ -31,7 +31,9 @@ import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests for {@link java.beans.PropertyChangeSupport}.

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ReflectionUtilTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/ReflectionUtilTest.java
@@ -23,7 +23,7 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/RegexPropertyFilterTest.java
@@ -18,16 +18,14 @@
  */
 package org.apache.tamaya.spisupport;
 
-import org.apache.tamaya.TypeLiteral;
 import org.apache.tamaya.spi.ConfigurationContext;
-import org.apache.tamaya.spi.ConversionContext;
 import org.apache.tamaya.spi.FilterContext;
 import org.apache.tamaya.spi.PropertyValue;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link RegexPropertyFilter}. Created by anatole on 11.02.16.

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/BasePropertySourceTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BasePropertySourceTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/CLIPropertySourceTest.java
@@ -22,7 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for PropertySource for reading main arguments as configuration.

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/EnvironmentPropertySourceTest.java
@@ -26,7 +26,6 @@ import java.io.StringWriter;
 import java.util.Map;
 
 import org.apache.tamaya.spi.PropertyValue;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -34,122 +33,122 @@ import org.junit.Test;
  */
 public class EnvironmentPropertySourceTest {
 
-	private final EnvironmentPropertySource envPropertySource = new EnvironmentPropertySource();
+    private final EnvironmentPropertySource envPropertySource = new EnvironmentPropertySource();
 
-	@Test
-	public void testConstructionPropertiesAndDisabledBehavior() throws IOException {
-		EnvironmentPropertySource localEnvironmentPropertySource;
-		StringWriter stringBufferWriter = new StringWriter();
-		System.getProperties().store(stringBufferWriter, null);
-		String before = stringBufferWriter.toString();
+    @Test
+    public void testConstructionPropertiesAndDisabledBehavior() throws IOException {
+        EnvironmentPropertySource localEnvironmentPropertySource;
+        StringWriter stringBufferWriter = new StringWriter();
+        System.getProperties().store(stringBufferWriter, null);
+        String before = stringBufferWriter.toString();
 
-		try {
-			assertThat(envPropertySource.isDisabled()).isFalse();
+        try {
+            assertThat(envPropertySource.isDisabled()).isFalse();
 
-			System.setProperty("tamaya.envprops.prefix", "fakeprefix");
-			System.setProperty("tamaya.envprops.disable", "true");
-			localEnvironmentPropertySource = new EnvironmentPropertySource();
-			assertThat(localEnvironmentPropertySource.getPrefix()).isEqualTo("fakeprefix");
-			assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
-			assertThat(localEnvironmentPropertySource.get(System.getenv().entrySet().iterator().next().getKey()))
-					.isNull();
-			assertThat(localEnvironmentPropertySource.getName()).contains("(disabled)");
-			assertThat(localEnvironmentPropertySource.getProperties()).isEmpty();
-			assertThat(localEnvironmentPropertySource.toString()).contains("disabled=true");
+            System.setProperty("tamaya.envprops.prefix", "fakeprefix");
+            System.setProperty("tamaya.envprops.disable", "true");
+            localEnvironmentPropertySource = new EnvironmentPropertySource();
+            assertThat(localEnvironmentPropertySource.getPrefix()).isEqualTo("fakeprefix");
+            assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
+            assertThat(localEnvironmentPropertySource.get(System.getenv().entrySet().iterator().next().getKey()))
+                    .isNull();
+            assertThat(localEnvironmentPropertySource.getName()).contains("(disabled)");
+            assertThat(localEnvironmentPropertySource.getProperties()).isEmpty();
+            assertThat(localEnvironmentPropertySource.toString()).contains("disabled=true");
 
-			System.getProperties().clear();
-			System.getProperties().load(new StringReader(before));
-			System.setProperty("tamaya.defaults.disable", "true");
-			localEnvironmentPropertySource = new EnvironmentPropertySource();
-			assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
+            System.getProperties().clear();
+            System.getProperties().load(new StringReader(before));
+            System.setProperty("tamaya.defaults.disable", "true");
+            localEnvironmentPropertySource = new EnvironmentPropertySource();
+            assertThat(localEnvironmentPropertySource.isDisabled()).isTrue();
 
-			System.getProperties().clear();
-			System.getProperties().load(new StringReader(before));
-			System.setProperty("tamaya.envprops.disable", "");
-			localEnvironmentPropertySource = new EnvironmentPropertySource();
-			assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
+            System.getProperties().clear();
+            System.getProperties().load(new StringReader(before));
+            System.setProperty("tamaya.envprops.disable", "");
+            localEnvironmentPropertySource = new EnvironmentPropertySource();
+            assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
 
-			System.getProperties().clear();
-			System.getProperties().load(new StringReader(before));
-			System.setProperty("tamaya.defaults.disable", "");
-			localEnvironmentPropertySource = new EnvironmentPropertySource();
-			assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
+            System.getProperties().clear();
+            System.getProperties().load(new StringReader(before));
+            System.setProperty("tamaya.defaults.disable", "");
+            localEnvironmentPropertySource = new EnvironmentPropertySource();
+            assertThat(localEnvironmentPropertySource.isDisabled()).isFalse();
 
-		} finally {
-			System.getProperties().clear();
-			System.getProperties().load(new StringReader(before));
-		}
-	}
+        } finally {
+            System.getProperties().clear();
+            System.getProperties().load(new StringReader(before));
+        }
+    }
 
-	@Test
-	public void testGetOrdinal() throws Exception {
-		assertThat(envPropertySource.getOrdinal()).isEqualTo(EnvironmentPropertySource.DEFAULT_ORDINAL);
-		EnvironmentPropertySource constructorSetOrdinal22 = new EnvironmentPropertySource(22);
-		assertThat(constructorSetOrdinal22.getOrdinal()).isEqualTo(22);
+    @Test
+    public void testGetOrdinal() throws Exception {
+        assertThat(envPropertySource.getOrdinal()).isEqualTo(EnvironmentPropertySource.DEFAULT_ORDINAL);
+        EnvironmentPropertySource constructorSetOrdinal22 = new EnvironmentPropertySource(22);
+        assertThat(constructorSetOrdinal22.getOrdinal()).isEqualTo(22);
 
-		EnvironmentPropertySource constructorSetOrdinal16 = new EnvironmentPropertySource("sixteenprefix", 16);
-		assertThat(constructorSetOrdinal16.getOrdinal()).isEqualTo(16);
+        EnvironmentPropertySource constructorSetOrdinal16 = new EnvironmentPropertySource("sixteenprefix", 16);
+        assertThat(constructorSetOrdinal16.getOrdinal()).isEqualTo(16);
 
-	}
+    }
 
-	@Test
-	public void testGetName() throws Exception {
-		assertThat(envPropertySource.getName()).isEqualTo("environment-properties");
-	}
+    @Test
+    public void testGetName() throws Exception {
+        assertThat(envPropertySource.getName()).isEqualTo("environment-properties");
+    }
 
   @Test
   public void testSingleCharacterNull() {
     assertThat(envPropertySource.get("a")).isNull();
   }
 
-	@Test
-	public void testGet() throws Exception {
-		for (Map.Entry<String, String> envEntry : System.getenv().entrySet()) {
-			assertThat(envEntry.getValue()).isEqualTo(envPropertySource.get(envEntry.getKey()).getValue());
-		}
-	}
+    @Test
+    public void testGet() throws Exception {
+        for (Map.Entry<String, String> envEntry : System.getenv().entrySet()) {
+            assertThat(envEntry.getValue()).isEqualTo(envPropertySource.get(envEntry.getKey()).getValue());
+        }
+    }
 
-	@Test
-	public void testPrefixedGet() throws Exception {
-		EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("fancyprefix");
-		System.out.println(localEnvironmentPropertySource);
-		assertThat(localEnvironmentPropertySource.getPrefix()).isEqualTo("fancyprefix");
-		localEnvironmentPropertySource.setPropertiesProvider(new MockedSystemPropertiesProvider());
-		assertThat(localEnvironmentPropertySource.get("somekey").getValue()).isEqualTo("somekey.createValue");
-	}
+    @Test
+    public void testPrefixedGet() throws Exception {
+        EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("fancyprefix");
+        System.out.println(localEnvironmentPropertySource);
+        assertThat(localEnvironmentPropertySource.getPrefix()).isEqualTo("fancyprefix");
+        localEnvironmentPropertySource.setPropertiesProvider(new MockedSystemPropertiesProvider());
+        assertThat(localEnvironmentPropertySource.get("somekey").getValue()).isEqualTo("somekey.createValue");
+    }
 
-	@Test
-	public void testGetProperties() throws Exception {
-		Map<String, PropertyValue> props = envPropertySource.getProperties();
-		for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
-			if (!en.getKey().startsWith("_")) {
-				assertThat(en.getValue().getValue()).isEqualTo(System.getenv(en.getKey()));
-			}
-		}
-	}
+    @Test
+    public void testGetProperties() throws Exception {
+        Map<String, PropertyValue> props = envPropertySource.getProperties();
+        for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
+            if (!en.getKey().startsWith("_")) {
+                assertThat(en.getValue().getValue()).isEqualTo(System.getenv(en.getKey()));
+            }
+        }
+    }
 
-	@Test
-	public void testPrefixedGetProperties() throws Exception {
-		EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("someprefix");
-		Map<String, PropertyValue> props = localEnvironmentPropertySource.getProperties();
-		for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
-			assertThat(en.getKey().startsWith("someprefix")).isTrue();
-			String thisKey = en.getKey().replaceFirst("someprefix", "");
-			if (!thisKey.startsWith("_")) {
-				assertThat(en.getValue().getValue()).isEqualTo(System.getenv(thisKey));
-			}
-		}
-	}
+    @Test
+    public void testPrefixedGetProperties() throws Exception {
+        EnvironmentPropertySource localEnvironmentPropertySource = new EnvironmentPropertySource("someprefix");
+        Map<String, PropertyValue> props = localEnvironmentPropertySource.getProperties();
+        for (Map.Entry<String, PropertyValue> en : props.entrySet()) {
+            assertThat(en.getKey().startsWith("someprefix")).isTrue();
+            String thisKey = en.getKey().replaceFirst("someprefix", "");
+            if (!thisKey.startsWith("_")) {
+                assertThat(en.getValue().getValue()).isEqualTo(System.getenv(thisKey));
+            }
+        }
+    }
 
-	@Test
-	public void testIsScannable() throws Exception {
-		assertThat(envPropertySource.isScannable()).isTrue();
-	}
+    @Test
+    public void testIsScannable() throws Exception {
+        assertThat(envPropertySource.isScannable()).isTrue();
+    }
 
-	private class MockedSystemPropertiesProvider extends EnvironmentPropertySource.SystemPropertiesProvider {
-		@Override
-		String getenv(String key) {
-			return key + ".createValue";
-		}
-	}
+    private class MockedSystemPropertiesProvider extends EnvironmentPropertySource.SystemPropertiesProvider {
+        @Override
+        String getenv(String key) {
+            return key + ".createValue";
+        }
+    }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/JavaConfigurationProviderTest.java
@@ -21,11 +21,9 @@ package org.apache.tamaya.spisupport.propertysource;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import org.apache.tamaya.spi.PropertySource;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaConfigurationProviderTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/MapPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/MapPropertySourceTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tamaya.spisupport.propertysource;
 
-import org.apache.tamaya.spisupport.propertysource.MapPropertySource;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesFilePropertySourceTest.java
@@ -21,7 +21,7 @@ package org.apache.tamaya.spisupport.propertysource;
 import org.apache.tamaya.spi.PropertySource;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertiesFilePropertySourceTest {
 

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySourceTest.java
@@ -20,8 +20,8 @@ package org.apache.tamaya.spisupport.propertysource;
 
 import java.net.URL;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
- 	
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/SimplePropertySourceTest.java
@@ -31,7 +31,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class SimplePropertySourceTest {
 
@@ -233,17 +234,17 @@ public class SimplePropertySourceTest {
         assertThat(sps.getProperties()).contains(entry("a", PropertyValue.of("a", "b", resource.toString())));
         assertThat(sps.getProperties()).contains(entry("b", PropertyValue.of("b", "1", resource.toString())));
     }
-    
+
     @Test
     public void buildingWithValidName() {
-    	final String KEY = "myTestKey"; 
-    	Builder builder = SimplePropertySource.newBuilder().withName(KEY);
-    	assertThat(builder.build().getName()).isEqualTo(KEY);
+        final String key = "myTestKey";
+        Builder builder = SimplePropertySource.newBuilder().withName(key);
+        assertThat(builder.build().getName()).isEqualTo(key);
     }
-    
+
     @Test(expected = NullPointerException.class)
     public void buildingWithInvalidNameYieldsNPE() {
-    	SimplePropertySource.newBuilder().withName(null);
+        SimplePropertySource.newBuilder().withName(null);
     }
-    
+
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/propertysource/WrappedPropertySourceTest.java
@@ -23,7 +23,8 @@ import java.util.Map;
 import org.apache.tamaya.spi.PropertySource;
 import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/services/DefaultServiceContext.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/services/DefaultServiceContext.java
@@ -63,7 +63,7 @@ public final class DefaultServiceContext implements ServiceContext {
      */
     private final Map<Class<?>, Object> singletons = new ConcurrentHashMap<>();
     @SuppressWarnings("rawtypes")
-	private Map<Class, Class> factoryTypes = new ConcurrentHashMap<>();
+    private Map<Class, Class> factoryTypes = new ConcurrentHashMap<>();
 
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,8 @@
                     </executions>
                     <configuration>
                         <logViolationsToConsole>true</logViolationsToConsole>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <suppressionsLocation>buildconfigurations/src/main/resources/checkstyle/suppressions.xml</suppressionsLocation>
                         <configLocation>buildconfigurations/src/main/resources/checkstyle/style.xml</configLocation>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
This also adds a `supressions.xml` file so that we don't need to be quite so rigorous for the test code (e.g. I don't think JavaDocs are particularly necessary for test code).

Otherwise, most of the changes fall into three categories:

* Update import statements (replace star imports with explicit imports, remove unused imports)
* Replace tabs with spaces
* static constants are made UPPER_CASE