### PR TITLE
TAMAYA-219: Prohibit non-AssertJ test assertions

### DIFF
--- a/buildconfigurations/src/main/resources/checkstyle/style.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/style.xml
@@ -74,7 +74,10 @@ under the License.
             <property name="excludes"
                       value="java.io,java.net,java.util"/>
         </module>
-        <module name="IllegalImport"/>
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="junit.framework.TestCase, org.junit.Assert, org.hamcrest.MatcherAssert, org.hamcrest.CoreMatchers, org.hamcrest.Matchers, org.hamcrest.core.Is"/>
+            <property name="illegalPkgs" value="junit.framework.TestCase, org.junit.Assert, org.hamcrest.MatcherAssert, org.hamcrest.CoreMatchers, org.hamcrest.Matchers, org.hamcrest.core.Is"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 


### PR DESCRIPTION
The `illegalClasses` section is for non-static imports (e.g. `import org.junit.Assert`), and the `illegalPkgs` section covers static imports (e.g. `import static org.junit.Assert.assertTrue`).

