### PR TITLE
TAMAYA-383 Let OSGi skip thread classloader key

### DIFF
--- a/code/core/src/main/java/org/apache/tamaya/core/OSGIActivator.java
+++ b/code/core/src/main/java/org/apache/tamaya/core/OSGIActivator.java
@@ -46,7 +46,7 @@ public class OSGIActivator implements BundleActivator {
         // Register marker service
         this.serviceLoader = new OSGIServiceLoader(context);
         context.addBundleListener(serviceLoader);
-        ServiceContextManager.set(new OSGIServiceContext(serviceLoader));
+        ServiceContextManager.setToStaticClassLoader(new OSGIServiceContext(serviceLoader));
         LOG.info("Registered Tamaya OSGI ServiceContext...");
         Configuration.setCurrent(
                        new CoreConfigurationBuilder()


### PR DESCRIPTION
We use the thread's classloader as a key into a hashmap to find the
serviceloader for a given configuration.  In OSGi, we have separate
classloaders for the CoreConfigurationBuilder,
DefaultConfigurationBuilder, and ServiceContextManager.  That confusion
prevents the simple case from finding a match in the hashmap that can
load a particular ServiceContext.  Since
CoreConfiguation/DefaultConfiguration already uses the static class's
classloader during <init>, this PR allows the OSGIActivator to point
that classloader at the relevant OSGIServiceContext.

With these changes I was able to get the bundles to start in an Apache Karaf instance.