### PR TITLE
TAMAYA-277 adjust sonar configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
 language: java
 dist: trusty
-jdk:
-  - openjdk8
-  - openjdk9
-  - openjdk10
-  - openjdk11
 
-#before_script:
-#  - pip install --user codecov
-
-#after_success:
-#  - codecov
-
-#addons:
-#  srcclr: true 
 addons:
   sonarcloud:
     organization: apache
 
-script:
-  # other script steps might be done before running the actual analysis
-  #- sonar-scanner
-  - mvn clean verify install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+jobs:
+    include:
+        - name: "Java 8"
+          jdk: openjdk8
+          script: mvn clean verify install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+
+        - name: "Java 9"
+          jdk: openjdk9
+          script: mvn clean verify install
+
+        - name: "Java 10"
+          jdk: openjdk10
+          script: mvn clean verify install
+
+        - name: "Java 11"
+          jdk: openjdk11
+          script: mvn clean verify install
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ jdk:
 #  srcclr: true 
 addons:
   sonarcloud:
-    organization: "apache" 
-    token: "$SONAR_TOKEN"
+    organization: apache
+
 script:
   # other script steps might be done before running the actual analysis
   #- sonar-scanner
-  - mvn clean verify install sonar:sonar
+  - mvn clean verify install sonar:sonar -Dsonar.login=$SONAR_TOKEN
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ jdk:
 addons:
   sonarcloud:
     organization: "apache" 
+    token: "$SONAR_TOKEN"
 script:
   # other script steps might be done before running the actual analysis
-  - sonar-scanner
-#  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+  #- sonar-scanner
+  - mvn clean verify install sonar:sonar

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ addons:
 script:
   # other script steps might be done before running the actual analysis
   #- sonar-scanner
-  - mvn clean verify install sonar:sonar -Dsonar.login=$SONAR_TOKEN
+  - mvn clean verify install sonar:sonar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ dist: trusty
 
 addons:
   sonarcloud:
-    organization: apache
+    organization: "apache"
 
 jobs:
     include:
         - name: "Java 8"
           jdk: openjdk8
-          script: mvn clean verify install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+          script: mvn clean verify install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url="https://sonarcloud.io" -Dsonar.login="$SONAR_TOKEN"
 
         - name: "Java 9"
           jdk: openjdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ addons:
 script:
   # other script steps might be done before running the actual analysis
   #- sonar-scanner
-  - mvn clean verify install sonar:sonar
+  - mvn clean verify install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
 

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -98,7 +98,7 @@ under the License.
                     <!--
                      ! Add -Djava.security.debug=all for debugging if needed
                      !-->
-                    <argLine>-Djava.security.policy=${project.basedir}/src/test/resources/java-security.policy</argLine>
+                    <argLine>-Djava.security.policy=${project.basedir}/src/test/resources/java-security.policy ${argLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
         <!-- API checker -->
         <revapi-java.version>0.18.0</revapi-java.version>
         <revapi.plugin.version>0.10.5</revapi.plugin.version>
-
-        <!-- Sonar properties -->
-        <sonar.projectName>Apache Tamaya - Java Configuration</sonar.projectName>
-        <sonar.projectKey>apache_incubator-tamaya</sonar.projectKey>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <!-- Sonar properties -->
         <sonar.projectName>Apache Tamaya - Java Configuration</sonar.projectName>
         <sonar.projectKey>apache_incubator-tamaya</sonar.projectKey>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 
         <!-- Sonar properties -->
         <sonar.projectName>Apache Tamaya - Java Configuration</sonar.projectName>
-        <sonar.projectKey>apache:apache_incubator-tamaya</sonar.projectKey>
         <sonar.links.homepage>https://tamaya.apache.org/</sonar.links.homepage>
         <sonar.links.scm_dev>scm:git:git@github.com:apache/incubator-tamaya.git</sonar.links.scm_dev>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,7 @@
 
         <!-- Sonar properties -->
         <sonar.projectName>Apache Tamaya - Java Configuration</sonar.projectName>
-        <sonar.links.homepage>https://tamaya.apache.org/</sonar.links.homepage>
-        <sonar.links.scm_dev>scm:git:git@github.com:apache/incubator-tamaya.git</sonar.links.scm_dev>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.projectKey>apache_incubator-tamaya</sonar.projectKey>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <sonar.projectKey>apache:apache_incubator-tamaya</sonar.projectKey>
         <sonar.links.homepage>https://tamaya.apache.org/</sonar.links.homepage>
         <sonar.links.scm_dev>scm:git:git@github.com:apache/incubator-tamaya.git</sonar.links.scm_dev>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
         <!-- API checker -->
         <revapi-java.version>0.18.0</revapi-java.version>
         <revapi.plugin.version>0.10.5</revapi.plugin.version>
+
+        <!-- Sonar properties -->
+        <sonar.projectName>Apache Tamaya - Java Configuration</sonar.projectName>
+        <sonar.projectKey>apache:apache_incubator-tamaya</sonar.projectKey>
+        <sonar.links.homepage>https://tamaya.apache.org/</sonar.links.homepage>
+        <sonar.links.scm_dev>scm:git:git@github.com:apache/incubator-tamaya.git</sonar.links.scm_dev>
     </properties>
 
     <licenses>
@@ -352,11 +358,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${assembly.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>
@@ -697,6 +698,25 @@
                         </fileset>
                     </filesets>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                  <execution>
+                    <goals>
+                      <goal>prepare-agent</goal>
+                    </goals>
+                  </execution>
+                  <execution>
+                    <id>report</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                      <goal>report</goal>
+                    </goals>
+                  </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>


### PR DESCRIPTION
It's hard to actually test this, but there are a few adjustments here that should help. 

First, JaCoCo wasn't actually turned on for the `tamaya-core` module (overriding the `argLine` had removed JaCoCo's own override). 
Second, JaCoCo had to be manually invoked, by moving the configuration from `<pluginManagement>` to `<plugins>`, it is now tied to the `mvn verify` stage.
Next, it seems that the `SONAR_TOKEN` can be interpolated as shown in the adjustment to `.travis.yml`, and perhaps that is required
Finally, I added a number of sonar-specific properties directly to the `pom.xml` file.

@ottlinger has the SonarCloud token, so you might be able to test this locally. Or, you can just merge it and see how it works. My experience with SonarCloud integration involves gradle, so I don't have a working Maven config to share, but hopefully this will get us closer.