### PR TITLE
TAMAYA-387 Upgrade checkstyle plugin

### DIFF
--- a/buildconfigurations/src/main/resources/checkstyle/style.xml
+++ b/buildconfigurations/src/main/resources/checkstyle/style.xml
@@ -26,8 +26,6 @@ under the License.
         <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
 
-    <module name="SuppressionCommentFilter"/>
-
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength">
@@ -41,8 +39,7 @@ under the License.
 
 
     <module name="TreeWalker">
-        <!-- needed for the SuppressionCommentFilter -->
-        <module name="FileContentsHolder"/>
+        <module name="SuppressionCommentFilter"/>
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -402,13 +402,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.8</version>
-                            <exclusions><!-- MCHECKSTYLE-156 -->
-                                <exclusion>
-                                    <groupId>com.sun</groupId>
-                                    <artifactId>tools</artifactId>
-                                </exclusion>
-                            </exclusions>
+                            <version>8.19</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
This upgrades the checkstyle plugin to 8.19

The exclusion code in the maven configuration are no longer relevant,
and the style.xml file itself needed some minor modifications that go
along with the upgrade to the 8.x series