### PR TITLE
TAMAYA-77: Change sonar config to use mvn style for analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,11 @@ addons:
   sonarcloud:
     organization: "apache"
 
-script:
-  - sonar-scanner
-
 jobs:
     include:
         - name: "Java 8"
           jdk: openjdk8
-          # script: mvn clean install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya -Dsonar.host.url="https://sonarcloud.io" -Dsonar.login="$SONAR_TOKEN"
-          script: mvn clean install 
+           script: mvn clean install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya
 
         - name: "Java 9"
           jdk: openjdk9


### PR DESCRIPTION
As suggested by @bellingard in [this comment](https://github.com/apache/incubator-tamaya/commit/98bc730a4dbfd257fef02abf59c7f31397e1abef#r33292801), this simplifies the sonar configuration and ensures that it runs in the JDK8 environment on Travis-CI