### PR TITLE
LHF: remove unnecessary volatile keywords

### DIFF
--- a/code/api/src/main/java/org/apache/tamaya/spi/ServiceContextManager.java
+++ b/code/api/src/main/java/org/apache/tamaya/spi/ServiceContextManager.java
@@ -41,7 +41,7 @@ public final class ServiceContextManager {
     /**
      * The ServiceProvider used.
      */
-    private static volatile Map<ClassLoader, ServiceContext> serviceContexts = new ConcurrentHashMap<>();
+    private static final Map<ClassLoader, ServiceContext> SERVICE_CONTEXTS = new ConcurrentHashMap<>();
 
     /**
      * Private singletons constructor.
@@ -104,7 +104,7 @@ public final class ServiceContextManager {
 
         ServiceContext previousContext;
         synchronized (ServiceContextManager.class) {
-            previousContext = ServiceContextManager.serviceContexts
+            previousContext = ServiceContextManager.SERVICE_CONTEXTS
                     .put(cl, serviceContext);
         }
         if(previousContext!=null) {
@@ -127,7 +127,7 @@ public final class ServiceContextManager {
      */
     public static ServiceContext getServiceContext(ClassLoader classLoader) {
         Objects.requireNonNull(classLoader, "Classloader required.");
-        return serviceContexts.computeIfAbsent(classLoader, ServiceContextManager::loadDefaultServiceProvider);
+        return SERVICE_CONTEXTS.computeIfAbsent(classLoader, ServiceContextManager::loadDefaultServiceProvider);
     }
 
     /**

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/PropertiesResourcePropertySource.java
@@ -39,7 +39,7 @@ public class PropertiesResourcePropertySource extends BasePropertySource {
     /** The logger used. */
     private static final Logger LOGGER = Logger.getLogger(PropertiesResourcePropertySource.class.getName());
 
-    private volatile PropertySourceChangeSupport cachedProperties = new PropertySourceChangeSupport(
+    private final PropertySourceChangeSupport cachedProperties = new PropertySourceChangeSupport(
             ChangeSupport.SUPPORTED, this);
 
     /**

--- a/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySource.java
+++ b/code/spi-support/src/main/java/org/apache/tamaya/spisupport/propertysource/SystemPropertySource.java
@@ -37,9 +37,9 @@ public class SystemPropertySource extends BasePropertySource {
      */
     public static final int DEFAULT_ORDINAL = 1000;
 
-    private AtomicInteger savedHashcode = new AtomicInteger();
+    private final AtomicInteger savedHashcode = new AtomicInteger();
 
-    private volatile PropertySourceChangeSupport cachedProperties = new PropertySourceChangeSupport(
+    private final PropertySourceChangeSupport cachedProperties = new PropertySourceChangeSupport(
             ChangeSupport.SUPPORTED, this);
 
     /**


### PR DESCRIPTION
The Sonar analysis doesn't like the use of `volatile` on fields. This change removes the `volatile` keyword in places where the field doesn't need to be marked as `volatile`. That is, these are cases where the field is, in fact, `final`.

Where appropriate, this also adjusts the field formatting to align with checkstyle rules.