### PR TITLE
TAMAYA-277: Don't fail builds because of Sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ jobs:
     include:
         - name: "Java 8"
           jdk: openjdk8
-          script: mvn clean install sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya
+          script: mvn clean install
+          after_success: mvn sonar:sonar -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-tamaya
 
         - name: "Java 9"
           jdk: openjdk9


### PR DESCRIPTION
There is an ongoing discussion about this on the mailing list, but if it is determined that a failed Sonar build should *not* fail the entire CI task, this is a PR that should do the trick.

This PR comes from a remote fork, so this _should_ verify that such PRs would succeed, even if the Sonar analysis does not succeed.