### PR TITLE
TAMAYA-277: Add test assertions

### DIFF
--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationProviderTest.java
@@ -22,6 +22,7 @@ import org.apache.tamaya.Configuration;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Created by atsticks on 11.09.16.
@@ -30,7 +31,7 @@ public class CoreConfigurationProviderTest {
 
     @Test
     public void testInstantiation() throws Exception {
-        new CoreConfigurationProvider();
+        assertThatCode(() -> new CoreConfigurationProvider()).doesNotThrowAnyException();
     }
 
     @Test
@@ -53,11 +54,11 @@ public class CoreConfigurationProviderTest {
     @SuppressWarnings("deprecation")
     @Test
     public void setConfiguration() throws Exception {
-        new CoreConfigurationProvider()
+        assertThatCode(() -> new CoreConfigurationProvider()
                 .setConfiguration(new CoreConfigurationProvider().getConfiguration(
                         getClass().getClassLoader()),
                         getClass().getClassLoader()
-                );
+                )).doesNotThrowAnyException();
     }
 
     @SuppressWarnings("deprecation")

--- a/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
+++ b/code/core/src/test/java/org/apache/tamaya/core/internal/CoreConfigurationTest.java
@@ -48,6 +48,7 @@ public class CoreConfigurationTest {
     @Test
     public void testToString() throws Exception {
         String toString = Configuration.current().getContext().toString();
+        assertThat(toString).contains("Property Filters").contains("Property Converters");
     }
 
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationBuilderTest.java
@@ -32,6 +32,7 @@ import org.apache.tamaya.spi.PropertyValue;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for {@link  DefaultConfigurationBuilder} by atsticks on 06.09.16.
@@ -358,7 +359,7 @@ public class DefaultConfigurationBuilderTest {
     @Test
     public void bla() throws Exception {
         ConfigurationBuilder builder = ConfigurationProvider.getConfigurationBuilder();
-        builder.addDefaultPropertyConverters();
+        assertThatCode(() -> builder.addDefaultPropertyConverters()).doesNotThrowAnyException();
     }
 
     private static class TestPropertySource implements PropertySource {

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshotTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultConfigurationSnapshotTest.java
@@ -45,6 +45,7 @@ public class DefaultConfigurationSnapshotTest {
         Configuration config = Configuration.current();
         DefaultConfigurationSnapshot snapshot = new DefaultConfigurationSnapshot(config,
                 Arrays.asList("confkey1", "confkey2", "confkey3"));
+        assertThat(snapshot).isNotNull();
     }
 
     @Test

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/DefaultMetaDataProviderTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for {@link DefaultMetaDataProvider}.
@@ -33,7 +34,7 @@ public class DefaultMetaDataProviderTest {
 
     @Test
     public void cretion() {
-        new DefaultMetaDataProvider();
+        assertThatCode(() -> new DefaultMetaDataProvider()).doesNotThrowAnyException();
     }
 
     @Test
@@ -85,8 +86,10 @@ public class DefaultMetaDataProviderTest {
         assertThat(provider.getMetaData("foo")).isNotNull().isEmpty();
     }
 
-
     @Test
     public void testToString() {
+        DefaultMetaDataProvider provider = new DefaultMetaDataProvider();
+        assertThat(provider.init(ConfigurationContext.EMPTY).toString())
+            .isEqualTo("DefaultMetaDataProvider[additionalProperties = {}, context = ConfigurationContext.EMPTY]");
     }
 }

--- a/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
+++ b/code/spi-support/src/test/java/org/apache/tamaya/spisupport/PropertySourceChangeSupportTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -115,7 +116,7 @@ public class PropertySourceChangeSupportTest {
     public void update() {
         PropertySource ps = BuildablePropertySource.builder().withName("test").build();
         PropertySourceChangeSupport support = new PropertySourceChangeSupport(ChangeSupport.IMMUTABLE, ps);
-        support.load(Collections.emptyMap());
+        assertThatCode(() -> support.load(Collections.emptyMap())).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
This adds assertions to tests that lacked any, as reported by Sonar.