### PR TITLE
Prepare for next development iteration

### DIFF
--- a/buildconfigurations/pom.xml
+++ b/buildconfigurations/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-all</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>buildconfigurations</artifactId>

--- a/code/api/pom.xml
+++ b/code/api/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-code</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tamaya-api</artifactId>
@@ -40,7 +40,7 @@ under the License.
                 <artifactId>revapi-maven-plugin</artifactId>
                 <configuration>
                     <oldArtifacts>
-                        <artifact>${project.groupId}:${project.artifactId}:0.3-incubating</artifact>
+                        <artifact>${project.groupId}:${project.artifactId}:0.4-incubating</artifact>
                     </oldArtifacts>
                     <newArtifacts>
                         <artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>

--- a/code/core/pom.xml
+++ b/code/core/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-code</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tamaya-core</artifactId>
@@ -79,7 +79,7 @@ under the License.
                 <artifactId>revapi-maven-plugin</artifactId>
                 <configuration>
                     <oldArtifacts>
-                        <artifact>${project.groupId}:${project.artifactId}:0.3-incubating</artifact>
+                        <artifact>${project.groupId}:${project.artifactId}:0.4-incubating</artifact>
                     </oldArtifacts>
                     <newArtifacts>
                         <artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-all</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tamaya-code</artifactId>

--- a/code/spi-support/pom.xml
+++ b/code/spi-support/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-code</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tamaya-spisupport</artifactId>
@@ -40,7 +40,7 @@ under the License.
                 <artifactId>revapi-maven-plugin</artifactId>
                 <configuration>
                     <oldArtifacts>
-                        <artifact>${project.groupId}:${project.artifactId}:0.3-incubating</artifact>
+                        <artifact>${project.groupId}:${project.artifactId}:0.4-incubating</artifact>
                     </oldArtifacts>
                     <newArtifacts>
                         <artifact>${project.groupId}:${project.artifactId}:${project.version}</artifact>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-all</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tamaya-distribution</artifactId>

--- a/examples/01-minimal/pom.xml
+++ b/examples/01-minimal/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya.examples</groupId>
         <artifactId>examples</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>01-minimal</artifactId>

--- a/examples/02-custom-property-source/pom.xml
+++ b/examples/02-custom-property-source/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya.examples</groupId>
         <artifactId>examples</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>02-custom-property-source</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.tamaya</groupId>
         <artifactId>tamaya-all</artifactId>
-        <version>0.4-incubating</version>
+        <version>0.5-incubating-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <groupId>org.apache.tamaya</groupId>
     <artifactId>tamaya-all</artifactId>
-    <version>0.4-incubating</version>
+    <version>0.5-incubating-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Tamaya Base</name>
@@ -74,7 +74,7 @@
 
         <!-- Dependencies for site generation -->
         <reflow-skin.version>1.1.1</reflow-skin.version>
-        <released_version>0.3-incubating</released_version>
+        <released_version>0.4-incubating</released_version>
         <osgi.annotation.version>6.0.0</osgi.annotation.version>
         <!-- API checker -->
         <revapi-java.version>0.18.0</revapi-java.version>


### PR DESCRIPTION
Now that 0.4-incubating has been released, this updates the version to 0.5-incubating-SNAPSHOT, and adjusts the revapi plugin to point at the most recent release.